### PR TITLE
Simplify unblinding option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - name: nominal fit
         run: >- 
           rabbit_fit.py $RABBIT_OUTDIR/test_tensor.hdf5 -o $RABBIT_OUTDIR/
-          -t 0 --unblind '.*' --doImpacts --globalImpacts
+          -t 0 --unblind --doImpacts --globalImpacts
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           --computeHistCov --computeHistImpacts --computeVariations
           -m Basemodel
@@ -203,7 +203,7 @@ jobs:
       - name: chi2 fit
         run: >- 
           rabbit_fit.py $RABBIT_OUTDIR/test_tensor.hdf5 -o $RABBIT_OUTDIR/ --postfix chi2
-          -t 0 --unblind '.*' --chisqFit --externalCovariance --doImpacts --globalImpacts 
+          -t 0 --unblind --chisqFit --externalCovariance --doImpacts --globalImpacts 
           --saveHists --saveHistsPerProcess --computeHistErrors --computeHistErrorsPerProcess
           -m Project ch1 a -m Project ch1 b
 

--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -19,6 +19,14 @@ from wums import output_tools, logging  # isort: skip
 logger = None
 
 
+class OptionalListAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if len(values) == 0:
+            setattr(namespace, self.dest, [".*"])
+        else:
+            setattr(namespace, self.dest, values)
+
+
 def make_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -298,7 +306,11 @@ def make_parser():
         type=str,
         default=[],
         nargs="*",
-        help="Specify list of regex to unblind matching parameters of interest. E.g. use '^signal$' to unblind a parameter named signal or '.*' to unblind all.",
+        action=OptionalListAction,
+        help="""
+        Specify list of regex to unblind matching parameters of interest. 
+        E.g. use '--unblind ^signal$' to unblind a parameter named signal or '--unblind' to unblind all.
+        """,
     )
 
     return parser.parse_args()


### PR DESCRIPTION
Unblind all when calling `--unblind` w/o arguments, unblind specific parameters only with regex `--unblind '^x$' '^y$' `