### PR TITLE
Fix bug in plotting script

### DIFF
--- a/bin/rabbit_plot_hists.py
+++ b/bin/rabbit_plot_hists.py
@@ -428,7 +428,7 @@ def make_plot(
         if (
             h_data is not None
             and binwnorm is not None
-            and h_data.storage_type != hist.storage.Weight()
+            and h_data.storage_type != hist.storage.Weight
         ):
             # need hist with variances to handle bin width normaliztion
             h_data_tmp = hist.Hist(
@@ -1013,6 +1013,7 @@ def make_plots(
             to_xsc = lambda h: hh.scaleHist(h, 1.0 / (lumi * 1000))
         else:
             to_xsc = lambda h: h
+
         hist_data = to_xsc(hist_data)
         hist_inclusive = to_xsc(hist_inclusive)
         hist_stack = [to_xsc(h) for h in hist_stack]

--- a/rabbit/physicsmodels/physicsmodel.py
+++ b/rabbit/physicsmodels/physicsmodel.py
@@ -215,7 +215,7 @@ class Select(Channelmodel):
     def parse_args(cls, indata, channel, *args):
         """
         parsing the input arguments into the ratio constructor, is has to be called as
-        -m BaseModelChannel <ch num>
+        -m Select <ch num>
             <proc_0>,<proc_1>,...
             <axis_0>:<selection_0>,<axis_1>,<selection_1>...
 


### PR DESCRIPTION
h_data.storage_type != hist.storage.Weight() was always true because a class was compared to an instance of a class. 
As a result variances of a histogram were overridden with Poisson variances based on the counts, which is wrong in the case of unfolding.
This is fixed by comparing the class with a class now. 