### PR TITLE
Rename lnN systematic

### DIFF
--- a/rabbit/datacard_converter.py
+++ b/rabbit/datacard_converter.py
@@ -277,17 +277,17 @@ class DatacardConverter:
                 prange = (float(lo), float(hi))
 
             for c in channels:
-                writer.add_lnN_systematic(name, processes, c, 1.01, constrained=False)
+                writer.add_norm_systematic(name, processes, c, 1.01, constrained=False)
 
-        def add_lnN_syst(writer, name, process, channel, effect):
+        def add_norm_syst(writer, name, process, channel, effect):
             # Parse the effect (could be asymmetric like 0.9/1.1)
             if "/" in effect:
                 down, up = effect.split("/")
-                writer.add_lnN_systematic(
+                writer.add_norm_systematic(
                     name, process, channel, [(float(up), float(down))]
                 )
             else:
-                writer.add_lnN_systematic(name, process, channel, float(effect))
+                writer.add_norm_systematic(name, process, channel, float(effect))
 
         logger.info("loop over systematic variations")
         for syst in tqdm(self.parser.systematics, desc="Processing"):
@@ -321,7 +321,7 @@ class DatacardConverter:
 
                         if hist_up is None and hist_down is None:
                             # 'syst?' case
-                            add_lnN_syst(
+                            add_norm_syst(
                                 writer, syst["name"], process_name, bin_name, effect
                             )
                         else:
@@ -341,7 +341,7 @@ class DatacardConverter:
 
                 for (bin_name, process_name), effect in syst["effects"].items():
                     if effect not in ["-", "0"]:
-                        add_lnN_syst(
+                        add_norm_syst(
                             writer, syst["name"], process_name, bin_name, effect
                         )
 

--- a/rabbit/tensorwriter.py
+++ b/rabbit/tensorwriter.py
@@ -253,7 +253,7 @@ class TensorWriter:
 
         return logkavg_proc, var_name_out
 
-    def add_lnN_systematic(
+    def add_norm_systematic(
         self,
         name,
         process,

--- a/tests/make_tensor.py
+++ b/tests/make_tensor.py
@@ -202,13 +202,13 @@ if not args.skipMaskedChannels:
 
 # systematic uncertainties
 
-writer.add_lnN_systematic("norm", ["sig", "bkg", "bkg_2"], "ch0", 1.02)
-writer.add_lnN_systematic("norm", ["sig", "bkg"], "ch1", [1.02, 1.03])
+writer.add_norm_systematic("norm", ["sig", "bkg", "bkg_2"], "ch0", 1.02)
+writer.add_norm_systematic("norm", ["sig", "bkg"], "ch1", [1.02, 1.03])
 
-writer.add_lnN_systematic("bkg_norm", "bkg", "ch0", 1.05)
-writer.add_lnN_systematic("bkg_norm", "bkg", "ch1", 1.05)
+writer.add_norm_systematic("bkg_norm", "bkg", "ch0", 1.05)
+writer.add_norm_systematic("bkg_norm", "bkg", "ch1", 1.05)
 
-writer.add_lnN_systematic("bkg_2_norm", "bkg_2", "ch0", 1.1)
+writer.add_norm_systematic("bkg_2_norm", "bkg_2", "ch0", 1.1)
 
 # shape systematics for channel ch0
 


### PR DESCRIPTION
What was previously called add_lnN_systematic is a normalization systematic that is either log-normal or normal constrained, depending on the systematic type. The naming "lnN" was confusing and is now changed to "norm"