### PR TITLE
Backward compatibility

### DIFF
--- a/rabbit/physicsmodels/helpers.py
+++ b/rabbit/physicsmodels/helpers.py
@@ -118,7 +118,7 @@ class Term:
 
         channel_axes_names = [a.name for a in channel_axes]
 
-        self.has_data = not info["masked"] and len(processes) == 0
+        self.has_data = not info.get("masked", False) and len(processes) == 0
 
         self.exp_shape = tuple([len(a) for a in channel_axes])
 

--- a/rabbit/physicsmodels/physicsmodel.py
+++ b/rabbit/physicsmodels/physicsmodel.py
@@ -109,7 +109,7 @@ class Channelmodel(PhysicsModel):
             }
         }
 
-        self.has_data = not channel_info["masked"]
+        self.has_data = not channel_info.get("masked", False)
 
     def compute(self, params, observables):
         return observables

--- a/rabbit/physicsmodels/project.py
+++ b/rabbit/physicsmodels/project.py
@@ -24,7 +24,9 @@ class Project(Channelmodel):
         channel_axes = {a.name: a for a in info["axes"]}
 
         if len([n for n in axes_names if n not in channel_axes]) > 0:
-            raise RuntimeError(f"Axes {[n for n in axes_names if n not in channel_axes]} not found. Available axes are {[channel_axes.keys()]}")
+            raise RuntimeError(
+                f"Axes {[n for n in axes_names if n not in channel_axes]} not found. Available axes are {[channel_axes.keys()]}"
+            )
         hist_axes = [channel_axes[n] for n in axes_names]
 
         if len(hist_axes) != len(axes_names):

--- a/rabbit/physicsmodels/project.py
+++ b/rabbit/physicsmodels/project.py
@@ -23,6 +23,8 @@ class Project(Channelmodel):
         info = indata.channel_info[channel]
         channel_axes = {a.name: a for a in info["axes"]}
 
+        if len([n for n in axes_names if n not in channel_axes]) > 0:
+            raise RuntimeError(f"Axes {[n for n in axes_names if n not in channel_axes]} not found. Available axes are {[channel_axes.keys()]}")
         hist_axes = [channel_axes[n] for n in axes_names]
 
         if len(hist_axes) != len(axes_names):


### PR DESCRIPTION
In previous versions there were no masked channels. Setting a default value (False) for masked in case it doesn't exist in the input.