### PR TITLE
Add channels in expected order; small plot fixes

### DIFF
--- a/bin/rabbit_plot_cov.py
+++ b/bin/rabbit_plot_cov.py
@@ -284,6 +284,7 @@ def main():
                         suffix=suffix,
                         axes_names=axes_names,
                     )
+                    h_cov_channel = h_cov
                 elif len(instance.get("channels", {}).keys()) > 1:
                     # plot covariance matrix in each channel
                     nbins = np.prod(channel_hist.shape)
@@ -318,9 +319,19 @@ def main():
                         put_trailing=True,
                     )
 
+                    cov_channel_vals = (
+                        h_cov_channel.values()
+                        if hasattr(h_cov_channel, "values")
+                        else h_cov_channel
+                    )
+                    if len(cov_channel_vals.shape) > 2:
+                        flat = np.prod(
+                            cov_channel_vals.shape[: len(cov_channel_vals.shape) // 2]
+                        )
+                        cov_channel_vals = cov_channel_vals.reshape((flat, flat))
                     vals = np.reshape(
-                        h_cov_channel.values(),
-                        (h_cov_channel.shape[0], *h2d.shape[: len(h2d.shape) // 2]),
+                        cov_channel_vals,
+                        (cov_channel_vals.shape[0], *h2d.shape[: len(h2d.shape) // 2]),
                     )
                     h2d.values()[...] = np.reshape(vals, h2d.shape)
 
@@ -356,7 +367,7 @@ def main():
                             h_cov_i,
                             args,
                             channel=channel,
-                            axes=other_axes,
+                            axes_names=other_axes,
                             config=config,
                             meta=meta,
                             suffix=suffix,

--- a/bin/rabbit_plot_hists.py
+++ b/bin/rabbit_plot_hists.py
@@ -752,6 +752,7 @@ def make_plot(
                     closed=True,
                     facecolor=facecolor_pred,
                     edgecolor="black",
+                    alpha=facecolor_alpha_pred,
                 )
             )
             extra_labels_upper.append(pred_label)

--- a/rabbit/tensorwriter.py
+++ b/rabbit/tensorwriter.py
@@ -165,12 +165,16 @@ class TensorWriter:
         self.dict_sumw2[name] = {}
         self.dict_beta_variations[name] = {}
 
-        # add masked channels last and not masked channels first
+        # add masked channels last
         this_channel = {"axes": [a for a in axes], "masked": masked, "flow": flow}
         if masked:
             self.channels[name] = this_channel
         else:
-            self.channels = {name: this_channel, **self.channels}
+            self.channels = {
+                **{k: v for k, v in self.channels.items() if not v["masked"]},
+                name: this_channel,
+                **{k: v for k, v in self.channels.items() if v["masked"]},
+            }
 
         self.dict_logkavg[name] = {}
         self.dict_logkhalfdiff[name] = {}


### PR DESCRIPTION
This addresses issue #67 at least partially since the channels are now added one after the other and corresponding to what is expected when adding a data covariance across channels