### PR TITLE
ABCD: opt-in MC yield-correction factor (default off)

### DIFF
--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -497,7 +497,7 @@ def fit(args, fitter, ws, dofit=True):
         # per call instead of O(npar^2), so this works on problems
         # where the full covariance would be infeasible.
         _, grad = fitter.loss_val_grad()
-        npoi = int(fitter.poi_model.npoi)
+        npoi = int(fitter.param_model.npoi)
         noi_idx_in_x = np.asarray(fitter.indata.noiidxs, dtype=np.int64) + npoi
         poi_noi_idx = np.concatenate([np.arange(npoi, dtype=np.int64), noi_idx_in_x])
         edmval, cov_rows = fitter.edmval_cov_rows_hessfree(grad, poi_noi_idx)

--- a/rabbit/param_models/abcd_isomtmt_model.py
+++ b/rabbit/param_models/abcd_isomtmt_model.py
@@ -12,10 +12,14 @@ channel dicts automatically. The extended variants require at least 3 mt bins;
 the plain variants require at least 2.
 
 CLI syntax:
-    --paramModel ABCDIsoMT               <process> <channel>
-    --paramModel ExtendedABCDIsoMT       <process> <channel>
-    --paramModel SmoothABCDIsoMT         [order:N] <process> <channel>
-    --paramModel SmoothExtendedABCDIsoMT [order:N] <process> <channel>
+    --paramModel ABCDIsoMT               [yieldCorrection:0|1] <process> <channel>
+    --paramModel ExtendedABCDIsoMT       [yieldCorrection:0|1] <process> <channel>
+    --paramModel SmoothABCDIsoMT         [order:N] [yieldCorrection:0|1] <process> <channel>
+    --paramModel SmoothExtendedABCDIsoMT [params:file.hdf5 | order:N] \\
+                                         [yieldCorrection:0|1] <process> <channel>
+
+``yieldCorrection`` defaults to 0 (no MC factor); pass ``yieldCorrection:1``
+to enable the yield-level form. See the underlying ABCD model docstrings.
 
 Region layout (shared by all four):
 
@@ -50,22 +54,31 @@ def _isomtmt_regions(indata, channel_name):
     return mt_ax.size - 1, mt_ax.size - 2, mt_ax.size - 3
 
 
+def _pop_yield_correction(tokens):
+    """Consume an optional ``yieldCorrection:N`` token from the front of the list."""
+    if tokens and tokens[0].startswith("yieldCorrection:"):
+        return bool(int(tokens.pop(0).split(":", 1)[1]))
+    return False
+
+
 def _parse_isomtmt_args(tokens):
-    """Parse [order:N] <process> <channel> from a token list."""
+    """Parse [order:N] [yieldCorrection:0|1] <process> <channel> from a token list."""
     order = 1
     if tokens and tokens[0].startswith("order:"):
         order = int(tokens.pop(0).split(":", 1)[1])
+    yield_correction = _pop_yield_correction(tokens)
     if len(tokens) < 2:
         raise ValueError("Expected <process> <channel>")
     process = tokens.pop(0)
     channel = tokens.pop(0)
     if tokens:
         raise ValueError(f"Unexpected extra arguments: {tokens}")
-    return order, process, channel
+    return order, process, channel, yield_correction
 
 
 def _parse_isomtmt_args_with_params(tokens):
-    """Parse [params:file.hdf5 | order:N] <process> <channel> from a token list.
+    """Parse [params:file.hdf5 | order:N] [yieldCorrection:0|1] <process> <channel>
+    from a token list.
 
     ``params:`` and ``order:`` are mutually exclusive; the params file encodes
     the polynomial order via its stored ``order`` field.
@@ -81,13 +94,14 @@ def _parse_isomtmt_args_with_params(tokens):
 
     elif tokens and tokens[0].startswith("order:"):
         order = int(tokens.pop(0).split(":", 1)[1])
+    yield_correction = _pop_yield_correction(tokens)
     if len(tokens) < 2:
         raise ValueError("Expected <process> <channel>")
     process = tokens.pop(0)
     channel = tokens.pop(0)
     if tokens:
         raise ValueError(f"Unexpected extra arguments: {tokens}")
-    return order, process, channel, initial_params
+    return order, process, channel, initial_params, yield_correction
 
 
 class ABCDIsoMT(ABCD):
@@ -114,12 +128,17 @@ class ABCDIsoMT(ABCD):
     @classmethod
     def parse_args(cls, indata, *args, **kwargs):
         tokens = list(args)
+        yield_correction = _pop_yield_correction(tokens)
         if len(tokens) < 2:
-            raise ValueError("ABCDIsoMT expects: <process> <channel>")
+            raise ValueError(
+                "ABCDIsoMT expects: [yieldCorrection:0|1] <process> <channel>"
+            )
         process, channel = tokens[0], tokens[1]
         if len(tokens) > 2:
             raise ValueError(f"Unexpected extra arguments: {tokens[2:]}")
-        return cls(indata, process, channel, **kwargs)
+        return cls(
+            indata, process, channel, yield_correction=yield_correction, **kwargs
+        )
 
 
 class ExtendedABCDIsoMT(ExtendedABCD):
@@ -155,12 +174,17 @@ class ExtendedABCDIsoMT(ExtendedABCD):
     @classmethod
     def parse_args(cls, indata, *args, **kwargs):
         tokens = list(args)
+        yield_correction = _pop_yield_correction(tokens)
         if len(tokens) < 2:
-            raise ValueError("ExtendedABCDIsoMT expects: <process> <channel>")
+            raise ValueError(
+                "ExtendedABCDIsoMT expects: [yieldCorrection:0|1] <process> <channel>"
+            )
         process, channel = tokens[0], tokens[1]
         if len(tokens) > 2:
             raise ValueError(f"Unexpected extra arguments: {tokens[2:]}")
-        return cls(indata, process, channel, **kwargs)
+        return cls(
+            indata, process, channel, yield_correction=yield_correction, **kwargs
+        )
 
 
 class SmoothABCDIsoMT(SmoothABCD):
@@ -194,8 +218,15 @@ class SmoothABCDIsoMT(SmoothABCD):
     @classmethod
     def parse_args(cls, indata, *args, **kwargs):
         tokens = list(args)
-        order, process, channel = _parse_isomtmt_args(tokens)
-        return cls(indata, process, channel, order=order, **kwargs)
+        order, process, channel, yield_correction = _parse_isomtmt_args(tokens)
+        return cls(
+            indata,
+            process,
+            channel,
+            order=order,
+            yield_correction=yield_correction,
+            **kwargs,
+        )
 
 
 class SmoothExtendedABCDIsoMT(SmoothExtendedABCD):
@@ -240,14 +271,19 @@ class SmoothExtendedABCDIsoMT(SmoothExtendedABCD):
     @classmethod
     def parse_args(cls, indata, *args, **kwargs):
         tokens = list(args)
-        order, process, channel, initial_params = _parse_isomtmt_args_with_params(
-            tokens
-        )
+        (
+            order,
+            process,
+            channel,
+            initial_params,
+            yield_correction,
+        ) = _parse_isomtmt_args_with_params(tokens)
         return cls(
             indata,
             process,
             channel,
             order=order,
             initial_params=initial_params,
+            yield_correction=yield_correction,
             **kwargs,
         )

--- a/rabbit/param_models/abcd_model.py
+++ b/rabbit/param_models/abcd_model.py
@@ -87,16 +87,30 @@ class ABCD(ParamModel):
     ABCD background estimation model.
 
     Defines free parameters a_i, b_i, c_i for regions A, B, C per bin.
-    Region D (signal region) is derived: D_i = a_i * c_i / b_i * mc_factor_D_i,
-    where mc_factor_D_i = N_A^MC * N_C^MC / (N_B^MC * N_D^MC) accounts for
-    non-unity MC templates.
+    Region D (signal region) is derived from the ABCD relation. The
+    relation can be enforced at two levels:
+
+    - rnorm-level (default, ``yield_correction=False``):
+        ``rnorm_D = a · c / b``. Relation on yields then holds only when
+        ``norm_A · norm_C = norm_B · norm_D`` (e.g. all four MC templates
+        share the same per-bin shape, which is the typical case when the
+        regions are different bin-slices of the same channel).
+    - yield-level (``yield_correction=True``):
+        ``rnorm_D = (a · c / b) · mc_factor_D`` with
+        ``mc_factor_D = norm_A · norm_C / (norm_B · norm_D)``. This makes
+        ``nexp_A · nexp_C = nexp_B · nexp_D`` hold for arbitrary MC
+        templates, at the cost of folding the MC shape difference between
+        regions into the parametrisation.
 
     Parameters are pure model nuisances (npoi=0, npou=3*n_bins). Positivity
     is enforced inside compute() via tf.square() on the raw fit variables.
 
     CLI syntax:
-        --paramModel ABCD <process> <ch_A> [ax:val ...] <ch_B> [ax:val ...] \\
+        --paramModel ABCD [yieldCorrection:0] <process> \\
+                          <ch_A> [ax:val ...] <ch_B> [ax:val ...] \\
                           <ch_C> [ax:val ...] <ch_D> [ax:val ...]
+    where ``yieldCorrection:0`` is the default (no MC factor); pass
+    ``yieldCorrection:1`` to enable the yield-level form.
 
     Python constructor:
         ABCD(indata, "nonprompt",
@@ -114,6 +128,7 @@ class ABCD(ParamModel):
         channel_B,
         channel_C,
         channel_D,
+        yield_correction=False,
         **kwargs,
     ):
         """
@@ -122,8 +137,12 @@ class ABCD(ParamModel):
             abcd_process: name of the background process to apply ABCD to (str).
             channel_A/B/C/D: dicts {ch_name: {axis_name: bin_idx, ...}} defining
                 each ABCD region. An empty inner dict selects all bins of the channel.
+            yield_correction: if True, multiply ``rnorm_D`` by ``mc_factor_D`` to
+                enforce the ABCD relation on yields for arbitrary MC templates.
+                Default False.
         """
         self.indata = indata
+        self.yield_correction = yield_correction
 
         # Validate process
         proc_name = (
@@ -206,18 +225,26 @@ class ABCD(ParamModel):
         """Parse CLI arguments for ABCDModel.
 
         Syntax:
-            --paramModel ABCD <process> <ch_A> [ax:val ...] <ch_B> [ax:val ...] \\
+            --paramModel ABCD [yieldCorrection:0|1] <process> \\
+                              <ch_A> [ax:val ...] <ch_B> [ax:val ...] \\
                               <ch_C> [ax:val ...] <ch_D> [ax:val ...]
 
         Each channel name is followed by zero or more axis:value pairs.
-        Axis values are integers.
+        Axis values are integers. ``yieldCorrection`` defaults to 0 (no MC
+        factor); pass ``yieldCorrection:1`` to enable the yield-level form.
         """
         if len(args) < 5:
             raise ValueError(
-                "ABCDModel expects: process ch_A [ax:val ...] ch_B [ax:val ...] "
+                "ABCDModel expects: [yieldCorrection:0|1] process "
+                "ch_A [ax:val ...] ch_B [ax:val ...] "
                 "ch_C [ax:val ...] ch_D [ax:val ...]"
             )
         tokens = list(args)
+
+        yield_correction = False
+        if tokens and tokens[0].startswith("yieldCorrection:"):
+            yield_correction = bool(int(tokens.pop(0).split(":", 1)[1]))
+
         process = tokens.pop(0)
 
         def _parse_one_region(tokens, region_name):
@@ -242,7 +269,14 @@ class ABCD(ParamModel):
             raise ValueError(f"Unexpected extra arguments after channel_D: {tokens}")
 
         return cls(
-            indata, process, channel_A, channel_B, channel_C, channel_D, **kwargs
+            indata,
+            process,
+            channel_A,
+            channel_B,
+            channel_C,
+            channel_D,
+            yield_correction=yield_correction,
+            **kwargs,
         )
 
     def compute(self, param, full=False):
@@ -264,7 +298,9 @@ class ABCD(ParamModel):
         c = tf.square(param[2 * n :])
 
         b_safe = tf.where(b == 0.0, tf.ones_like(b) * 1e-10, b)
-        d = a * c / b_safe * self.mc_factor_D
+        d = a * c / b_safe
+        if self.yield_correction:
+            d = d * self.mc_factor_D
 
         nbins = self.indata.nbinsfull if full else self.indata.nbins
         rnorm = tf.ones([nbins, self.indata.nproc], dtype=self.indata.dtype)

--- a/rabbit/param_models/extended_abcd_model.py
+++ b/rabbit/param_models/extended_abcd_model.py
@@ -28,16 +28,23 @@ class ExtendedABCD(ParamModel):
     Extended ABCD background estimation model with 6 regions.
 
     Free parameters a_i, b_i, c_i, ax_i, bx_i for regions A, B, C, Ax, Bx.
-    Region D is derived: D = C * Ax * B² / (Bx * A²) * mc_factor_D.
+    Region D is derived: ``rnorm_D = c · ax · b² / (bx · a²)`` (default,
+    ``yield_correction=False``), or ``rnorm_D = (c · ax · b² / (bx · a²)) ·
+    mc_factor_D`` with ``mc_factor_D = norm_C · norm_Ax · norm_B² /
+    (norm_Bx · norm_A² · norm_D)`` when ``yield_correction=True``. The
+    factor enforces the extended-ABCD relation on yields for arbitrary MC
+    templates; see ABCD docstring for the rnorm-vs-yield discussion.
 
     Parameters are pure model nuisances (npoi=0, npou=5*n_bins). Positivity
     is enforced inside compute() via tf.square() on the raw fit variables.
 
     CLI syntax:
-        --paramModel ExtendedABCD <process> \\
+        --paramModel ExtendedABCD [yieldCorrection:0|1] <process> \\
             <ch_Ax> [ax:val ...] <ch_Bx> [ax:val ...] \\
             <ch_A>  [ax:val ...] <ch_B>  [ax:val ...] \\
             <ch_C>  [ax:val ...] <ch_D>  [ax:val ...]
+    where ``yieldCorrection:0`` is the default; pass ``yieldCorrection:1`` to
+    enable the yield-level form.
 
     Python constructor:
         ExtendedABCD(indata, "nonprompt",
@@ -59,6 +66,7 @@ class ExtendedABCD(ParamModel):
         channel_D,
         channel_Ax,
         channel_Bx,
+        yield_correction=False,
         **kwargs,
     ):
         """
@@ -67,8 +75,12 @@ class ExtendedABCD(ParamModel):
             abcd_process: name of the background process (str).
             channel_A/B/C/D: dicts {ch_name: {axis_name: bin_idx, ...}}.
             channel_Ax/Bx: extra sideband regions (further from signal than A/B).
+            yield_correction: if True, multiply ``rnorm_D`` by ``mc_factor_D`` to
+                enforce the extended-ABCD relation on yields for arbitrary
+                MC templates. Default False.
         """
         self.indata = indata
+        self.yield_correction = yield_correction
 
         # Validate process
         proc_name = (
@@ -172,19 +184,26 @@ class ExtendedABCD(ParamModel):
         """Parse CLI arguments for ExtendedABCD.
 
         Syntax:
-            --paramModel ExtendedABCD <process> \\
+            --paramModel ExtendedABCD [yieldCorrection:0|1] <process> \\
                          <ch_Ax> [ax:val ...] <ch_Bx> [ax:val ...] \\
                          <ch_A>  [ax:val ...] <ch_B>  [ax:val ...] \\
                          <ch_C>  [ax:val ...] <ch_D>  [ax:val ...]
+        ``yieldCorrection`` defaults to 0 (no MC factor); pass
+        ``yieldCorrection:1`` to enable the yield-level form.
         """
         if len(args) < 7:
             raise ValueError(
-                "ExtendedABCD expects: process "
+                "ExtendedABCD expects: [yieldCorrection:0|1] process "
                 "ch_Ax [ax:val ...] ch_Bx [ax:val ...] "
                 "ch_A [ax:val ...] ch_B [ax:val ...] "
                 "ch_C [ax:val ...] ch_D [ax:val ...]"
             )
         tokens = list(args)
+
+        yield_correction = False
+        if tokens and tokens[0].startswith("yieldCorrection:"):
+            yield_correction = bool(int(tokens.pop(0).split(":", 1)[1]))
+
         process = tokens.pop(0)
 
         def _parse_one_region(tokens, region_name):
@@ -219,6 +238,7 @@ class ExtendedABCD(ParamModel):
             channel_D,
             channel_Ax,
             channel_Bx,
+            yield_correction=yield_correction,
             **kwargs,
         )
 
@@ -240,7 +260,9 @@ class ExtendedABCD(ParamModel):
         # D = C * Ax * B² / (Bx * A²) * mc_factor_D
         a_safe = tf.where(a == 0.0, tf.ones_like(a) * 1e-10, a)
         bx_safe = tf.where(bx == 0.0, tf.ones_like(bx) * 1e-10, bx)
-        d = c * ax * b**2 / (bx_safe * a_safe**2) * self.mc_factor_D
+        d = c * ax * b**2 / (bx_safe * a_safe**2)
+        if self.yield_correction:
+            d = d * self.mc_factor_D
 
         nbins = self.indata.nbinsfull if full else self.indata.nbins
         rnorm = tf.ones([nbins, self.indata.nproc], dtype=self.indata.dtype)

--- a/rabbit/param_models/smooth_abcd_model.py
+++ b/rabbit/param_models/smooth_abcd_model.py
@@ -29,14 +29,20 @@ class SmoothABCD(ParamModel):
     Smooth ABCD background estimation model.
 
     Regions A, B, C have free parameters that follow an exponential polynomial
-    along the smoothing axis; region D is derived as d = a·c/b · mc_factor_D.
+    along the smoothing axis; region D is derived as ``d = a·c/b`` (default,
+    ``yield_correction=False``) or ``d = a·c/b · mc_factor_D`` with
+    ``mc_factor_D = norm_A · norm_C / (norm_B · norm_D)`` when
+    ``yield_correction=True``. See ABCD docstring for the rnorm-vs-yield
+    discussion.
 
     Parameters are pure model nuisances (npoi=0, npou=3·n_outer·(order+1)).
 
     CLI syntax:
-        --paramModel SmoothABCD <axis> [order:N] <process> \\
+        --paramModel SmoothABCD <axis> [order:N] [yieldCorrection:0|1] <process> \\
                      <ch_A> [ax:val ...] <ch_B> [ax:val ...] \\
                      <ch_C> [ax:val ...] <ch_D> [ax:val ...]
+    where ``yieldCorrection:0`` is the default; pass ``yieldCorrection:1`` to
+    enable the yield-level form.
 
     Python constructor:
         SmoothABCD(indata, "pt", "nonprompt",
@@ -57,6 +63,7 @@ class SmoothABCD(ParamModel):
         channel_C,
         channel_D,
         order=1,
+        yield_correction=False,
         **kwargs,
     ):
         """
@@ -66,9 +73,13 @@ class SmoothABCD(ParamModel):
             abcd_process: name of the background process (str).
             channel_A/B/C/D: dicts {ch_name: {axis_name: bin_idx, ...}}.
             order: polynomial degree in the exponent (default 1 = log-linear).
+            yield_correction: if True, multiply ``rnorm_D`` by ``mc_factor_D``
+                to enforce the ABCD relation on yields for arbitrary MC
+                templates. Default False.
         """
         self.indata = indata
         self.order = order
+        self.yield_correction = yield_correction
 
         # Validate process
         proc_name = (
@@ -236,13 +247,15 @@ class SmoothABCD(ParamModel):
         """Parse CLI arguments for SmoothABCD.
 
         Syntax:
-            --paramModel SmoothABCD <axis> [order:N] <process> \\
+            --paramModel SmoothABCD <axis> [order:N] [yieldCorrection:0|1] <process> \\
                          <ch_A> [ax:val ...] <ch_B> [ax:val ...] \\
                          <ch_C> [ax:val ...] <ch_D> [ax:val ...]
+        ``yieldCorrection`` defaults to 0 (no MC factor); pass
+        ``yieldCorrection:1`` to enable the yield-level form.
         """
         if len(args) < 6:
             raise ValueError(
-                "SmoothABCD expects: axis [order:N] process "
+                "SmoothABCD expects: axis [order:N] [yieldCorrection:0|1] process "
                 "ch_A [ax:val ...] ch_B [ax:val ...] ch_C [ax:val ...] ch_D [ax:val ...]"
             )
         tokens = list(args)
@@ -251,6 +264,10 @@ class SmoothABCD(ParamModel):
         order = 1
         if tokens and tokens[0].startswith("order:"):
             order = int(tokens.pop(0).split(":", 1)[1])
+
+        yield_correction = False
+        if tokens and tokens[0].startswith("yieldCorrection:"):
+            yield_correction = bool(int(tokens.pop(0).split(":", 1)[1]))
 
         if not tokens:
             raise ValueError("SmoothABCD: expected process name after axis/order")
@@ -286,6 +303,7 @@ class SmoothABCD(ParamModel):
             channel_C,
             channel_D,
             order=order,
+            yield_correction=yield_correction,
             **kwargs,
         )
 
@@ -317,7 +335,9 @@ class SmoothABCD(ParamModel):
         c_flat = tf.reshape(c, [-1])
 
         b_safe = tf.where(b_flat == 0.0, tf.ones_like(b_flat) * 1e-10, b_flat)
-        d_flat = a_flat * c_flat / b_safe * self.mc_factor_D
+        d_flat = a_flat * c_flat / b_safe
+        if self.yield_correction:
+            d_flat = d_flat * self.mc_factor_D
 
         nbins = self.indata.nbinsfull if full else self.indata.nbins
         rnorm = tf.ones([nbins, self.indata.nproc], dtype=self.indata.dtype)

--- a/rabbit/param_models/smooth_extended_abcd_model.py
+++ b/rabbit/param_models/smooth_extended_abcd_model.py
@@ -36,16 +36,22 @@ class SmoothExtendedABCD(ParamModel):
     Smooth ExtendedABCD background estimation model with 6 regions.
 
     Regions A, B, C, Ax, Bx have free parameters that follow an exponential
-    polynomial along the smoothing axis; region D is derived:
-        D = C * Ax * B² / (Bx * A²) * mc_factor_D.
+    polynomial along the smoothing axis; region D is derived as
+    ``rnorm_D = c · ax · b² / (bx · a²)`` (default,
+    ``yield_correction=False``) or with ``mc_factor_D = norm_C · norm_Ax ·
+    norm_B² / (norm_Bx · norm_A² · norm_D)`` multiplied in when
+    ``yield_correction=True``. See ABCD docstring for the rnorm-vs-yield
+    discussion.
 
     Parameters are pure model nuisances (npoi=0, npou=5·n_outer·(order+1)).
 
     CLI syntax:
-        --paramModel SmoothExtendedABCD <axis> [order:N] <process> \\
+        --paramModel SmoothExtendedABCD <axis> [order:N] [yieldCorrection:0|1] <process> \\
                      <ch_Ax> [ax:val ...] <ch_Bx> [ax:val ...] \\
                      <ch_A>  [ax:val ...] <ch_B>  [ax:val ...] \\
                      <ch_C>  [ax:val ...] <ch_D>  [ax:val ...]
+    where ``yieldCorrection:0`` is the default; pass ``yieldCorrection:1``
+    to enable the yield-level form.
 
     Python constructor:
         SmoothExtendedABCD(indata, "pt", "nonprompt",
@@ -71,6 +77,7 @@ class SmoothExtendedABCD(ParamModel):
         channel_Bx,
         order=1,
         initial_params=None,
+        yield_correction=False,
         **kwargs,
     ):
         """
@@ -81,9 +88,13 @@ class SmoothExtendedABCD(ParamModel):
             channel_A/B/C/D: dicts {ch_name: {axis_name: bin_idx, ...}}.
             channel_Ax/Bx: extra sideband regions (further from signal than A/B).
             order: polynomial degree in the exponent (default 1 = log-linear).
+            yield_correction: if True, multiply ``rnorm_D`` by ``mc_factor_D``
+                to enforce the extended-ABCD relation on yields for
+                arbitrary MC templates. Default False.
         """
         self.indata = indata
         self.order = order
+        self.yield_correction = yield_correction
 
         # Validate process
         proc_name = (
@@ -272,17 +283,21 @@ class SmoothExtendedABCD(ParamModel):
         """Parse CLI arguments for SmoothExtendedABCD.
 
         Syntax:
-            --paramModel SmoothExtendedABCD <axis> [params:file.hdf5] [order:N] <process> \\
+            --paramModel SmoothExtendedABCD <axis> [params:file.hdf5] [order:N] \\
+                         [yieldCorrection:0|1] <process> \\
                          <ch_Ax> [ax:val ...] <ch_Bx> [ax:val ...] \\
                          <ch_A>  [ax:val ...] <ch_B>  [ax:val ...] \\
                          <ch_C>  [ax:val ...] <ch_D>  [ax:val ...]
 
         The optional ``params:file.hdf5`` token loads a numpy array as initial
         parameter values (produced by setupRabbit.py --dumpSmoothingParams).
+        ``yieldCorrection`` defaults to 0 (no MC factor); pass
+        ``yieldCorrection:1`` to enable the yield-level form.
         """
         if len(args) < 8:
             raise ValueError(
-                "SmoothExtendedABCD expects: axis [params:file.hdf5] [order:N] process "
+                "SmoothExtendedABCD expects: axis [params:file.hdf5] [order:N] "
+                "[yieldCorrection:0|1] process "
                 "ch_Ax [ax:val ...] ch_Bx [ax:val ...] "
                 "ch_A [ax:val ...] ch_B [ax:val ...] "
                 "ch_C [ax:val ...] ch_D [ax:val ...]"
@@ -307,6 +322,10 @@ class SmoothExtendedABCD(ParamModel):
                 order = int(d["order"])
         elif tokens and tokens[0].startswith("order:"):
             order = int(tokens.pop(0).split(":", 1)[1])
+
+        yield_correction = False
+        if tokens and tokens[0].startswith("yieldCorrection:"):
+            yield_correction = bool(int(tokens.pop(0).split(":", 1)[1]))
 
         if not tokens:
             raise ValueError(
@@ -349,6 +368,7 @@ class SmoothExtendedABCD(ParamModel):
             channel_Bx,
             order=order,
             initial_params=initial_params,
+            yield_correction=yield_correction,
             **kwargs,
         )
 
@@ -393,7 +413,9 @@ class SmoothExtendedABCD(ParamModel):
 
         a_safe = tf.where(a_flat == 0.0, tf.ones_like(a_flat) * 1e-10, a_flat)
         bx_safe = tf.where(bx_flat == 0.0, tf.ones_like(bx_flat) * 1e-10, bx_flat)
-        d_flat = c_flat * ax_flat * b_flat**2 / (bx_safe * a_safe**2) * self.mc_factor_D
+        d_flat = c_flat * ax_flat * b_flat**2 / (bx_safe * a_safe**2)
+        if self.yield_correction:
+            d_flat = d_flat * self.mc_factor_D
 
         nbins = self.indata.nbinsfull if full else self.indata.nbins
         rnorm = tf.ones([nbins, self.indata.nproc], dtype=self.indata.dtype)


### PR DESCRIPTION
## Summary

Make the MC factor that the four ABCD param models (`ABCD`,
`ExtendedABCD`, `SmoothABCD`, `SmoothExtendedABCD`) multiply into
`rnorm_D` opt-in, default off. Previously it was always applied.

## Why

The factor

    mc_factor_D = norm_A · norm_C / (norm_B · norm_D)                          # 4-region
    mc_factor_D = norm_C · norm_Ax · norm_B² / (norm_Bx · norm_A² · norm_D)    # 6-region

enforces the ABCD relation **on yields** for arbitrary MC templates:

    nexp_A · nexp_C = nexp_B · nexp_D                                          # 4-region
    nexp_A² · nexp_Bx · nexp_D = nexp_C · nexp_Ax · nexp_B²                    # 6-region

It's a meaningful correction when the four regions have *different* MC
shapes. But the typical setup in this framework — different bin-slices
of the same channel, MC templates sharing the same per-bin shape — has
norm_A · norm_C = norm_B · norm_D element-wise, so the factor is
identically 1 and adds nothing. There are also parametrisations (e.g.
filling the histogram with bin volumes so the underlying density is
uniform) where multiplying by the factor is conceptually wrong because
the params already encode the shape via the per-bin MC.

So the factor should be a deliberate choice, not the implicit default.

## Behaviour change

- **Default (\`yield_correction=False\`):** \`rnorm_D = a · c / b\`
  (4-region) or \`rnorm_D = c · ax · b² / (bx · a²)\` (6-region). The
  ABCD relation holds at rnorm level.
- **Opt-in (\`yield_correction=True\`):** previous behaviour — multiply in
  \`mc_factor_D\` to enforce the yield-level relation regardless of MC
  shapes.

For setups where the MC templates already satisfy the geometric
relation (same shape across regions), the two paths give identical fit
results.

## CLI

New \`yieldCorrection:0|1\` token in each parser:

    --paramModel ABCD               [yieldCorrection:0|1] <process> <ch_A> ... <ch_D>
    --paramModel ExtendedABCD       [yieldCorrection:0|1] <process> <ch_Ax> ... <ch_D>
    --paramModel SmoothABCD         <axis> [order:N] [yieldCorrection:0|1] <process> ...
    --paramModel SmoothExtendedABCD <axis> [params:file.hdf5 | order:N] [yieldCorrection:0|1] <process> ...

The four \`ABCDIsoMT\` convenience wrappers accept it too.

## Test plan

- [x] Compile-check passes (\`python -m py_compile\` on all five model files).
- [x] Same-shape per-region MC: \`yieldCorrection:0\` (default) and
      \`yieldCorrection:1\` give identical fit results because
      \`mc_factor_D ≡ 1\`.
- [x] Different per-region MC shapes: \`yieldCorrection:1\` reproduces
      pre-PR behaviour, \`yieldCorrection:0\` gives the rnorm-level
      relation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)