### PR TITLE
Restore vanilla external postfit support 

### DIFF
--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -450,69 +450,73 @@ def fit(args, fitter, ws, dofit=True):
     # prefit variances as the default fallback for add_parms_hist below
     parms_variances = None
 
-    if not args.noEDM and not args.noHessian:
-        # compute the covariance matrix and estimated distance to minimum
-        _, grad, hess = fitter.loss_val_grad_hess()
-        edmval, cov = fitter.edmval_cov(grad, hess)
-        logger.info(f"edmval: {edmval}")
+    # take covariance from externalPostfit in case the fit was skipped
+    if dofit or args.externalPostfit is None:
+        if not args.noEDM and not args.noHessian:
+            # compute the covariance matrix and estimated distance to minimum
+            _, grad, hess = fitter.loss_val_grad_hess()
+            edmval, cov = fitter.edmval_cov(grad, hess)
+            logger.info(f"edmval: {edmval}")
 
-        ws.add_cov_hist(cov)
+            ws.add_cov_hist(cov)
 
-        fitter.cov.assign(cov)
-        del cov
+            fitter.cov.assign(cov)
+            del cov
 
-        if fitter.bbstat.enabled and fitter.diagnostics:
-            # This is the estimated distance to minimum with respect to variations of
-            # the implicit binByBinStat nuisances beta at fixed parameter values.
-            # It should be near-zero by construction as long as the analytic profiling is
-            # correct
-            _, gradbeta, hessbeta = fitter.loss_val_grad_hess_beta()
-            edmvalbeta = edmval_cov(gradbeta, hessbeta)
-            logger.info(f"edmvalbeta: {edmvalbeta}")
+            if fitter.bbstat.enabled and fitter.diagnostics:
+                # This is the estimated distance to minimum with respect to variations of
+                # the implicit binByBinStat nuisances beta at fixed parameter values.
+                # It should be near-zero by construction as long as the analytic profiling is
+                # correct
+                _, gradbeta, hessbeta = fitter.loss_val_grad_hess_beta()
+                edmvalbeta = edmval_cov(gradbeta, hessbeta)
+                logger.info(f"edmvalbeta: {edmvalbeta}")
 
-        if args.doImpacts:
-            ws.add_impacts_hists(*fitter.impacts_parms(hess))
+            if args.doImpacts:
+                ws.add_impacts_hists(*fitter.impacts_parms(hess))
 
-        del hess
+            del hess
 
-        if args.globalImpacts:
-            ws.add_impacts_hists(
-                *fitter.global_impacts_parms(),
-                base_name="global_impacts",
-                global_impacts=True,
+            if args.globalImpacts:
+                ws.add_impacts_hists(
+                    *fitter.global_impacts_parms(),
+                    base_name="global_impacts",
+                    global_impacts=True,
+                )
+
+            if args.gaussianGlobalImpacts:
+                ws.add_impacts_hists(
+                    *fitter.gaussian_global_impacts_parms(),
+                    base_name="gaussian_global_impacts",
+                    global_impacts=True,
+                )
+
+            parms_variances = tf.linalg.diag_part(fitter.cov)
+        elif not args.noEDM:
+            # --noHessian: avoid the full dense Hessian. Still compute edmval
+            # and the POI+NOI uncertainties via a Hessian-free conjugate
+            # gradient solve of H @ v = grad and H @ c_i = e_i, using only
+            # Hessian-vector products. The CG solves touch O(npar) memory
+            # per call instead of O(npar^2), so this works on problems
+            # where the full covariance would be infeasible.
+            _, grad = fitter.loss_val_grad()
+            npoi = int(fitter.param_model.npoi)
+            noi_idx_in_x = np.asarray(fitter.indata.noiidxs, dtype=np.int64) + npoi
+            poi_noi_idx = np.concatenate(
+                [np.arange(npoi, dtype=np.int64), noi_idx_in_x]
             )
+            edmval, cov_rows = fitter.edmval_cov_rows_hessfree(grad, poi_noi_idx)
+            logger.info(f"edmval: {edmval}")
 
-        if args.gaussianGlobalImpacts:
-            ws.add_impacts_hists(
-                *fitter.gaussian_global_impacts_parms(),
-                base_name="gaussian_global_impacts",
-                global_impacts=True,
-            )
-
-        parms_variances = tf.linalg.diag_part(fitter.cov)
-    elif not args.noEDM:
-        # --noHessian: avoid the full dense Hessian. Still compute edmval
-        # and the POI+NOI uncertainties via a Hessian-free conjugate
-        # gradient solve of H @ v = grad and H @ c_i = e_i, using only
-        # Hessian-vector products. The CG solves touch O(npar) memory
-        # per call instead of O(npar^2), so this works on problems
-        # where the full covariance would be infeasible.
-        _, grad = fitter.loss_val_grad()
-        npoi = int(fitter.param_model.npoi)
-        noi_idx_in_x = np.asarray(fitter.indata.noiidxs, dtype=np.int64) + npoi
-        poi_noi_idx = np.concatenate([np.arange(npoi, dtype=np.int64), noi_idx_in_x])
-        edmval, cov_rows = fitter.edmval_cov_rows_hessfree(grad, poi_noi_idx)
-        logger.info(f"edmval: {edmval}")
-
-        # Build a full-length variance vector with the POI+NOI entries
-        # populated from the diagonal of the CG-solved rows and the rest
-        # left as NaN (we did not compute those). add_parms_hist stores
-        # the vector verbatim into the workspace.
-        n = int(fitter.x.shape[0])
-        parms_variances_np = np.full(n, np.nan, dtype=np.float64)
-        for k, i in enumerate(poi_noi_idx):
-            parms_variances_np[int(i)] = cov_rows[k, int(i)]
-        parms_variances = tf.constant(parms_variances_np, dtype=fitter.indata.dtype)
+            # Build a full-length variance vector with the POI+NOI entries
+            # populated from the diagonal of the CG-solved rows and the rest
+            # left as NaN (we did not compute those). add_parms_hist stores
+            # the vector verbatim into the workspace.
+            n = int(fitter.x.shape[0])
+            parms_variances_np = np.full(n, np.nan, dtype=np.float64)
+            for k, i in enumerate(poi_noi_idx):
+                parms_variances_np[int(i)] = cov_rows[k, int(i)]
+            parms_variances = tf.constant(parms_variances_np, dtype=fitter.indata.dtype)
 
     nllvalreduced = fitter.reduced_nll().numpy()
 


### PR DESCRIPTION
Lately it was not possible to skip the covariance matrix calculation and taking it from the external postfit instead for producing postfit distributions. This can now be done using `--externalPostfit <fitresult.hdf5> -t 0 --noFit`