### PR TITLE
asym impacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,7 @@ jobs:
         test:
           - test_bbstat.py
           - test_external_term.py
+          - test_global_asym_impacts.py
           - test_multi_systematic.py
           - test_sparse_fit.py
 

--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -247,13 +247,6 @@ def make_parser():
         help="Regex(es) excluding nuisances from --asymImpacts.",
     )
     parser.add_argument(
-        "--asymImpactsAll",
-        default=False,
-        action="store_true",
-        help="Disable the structural-symmetric skip in --asymImpacts and scan "
-        "every constrained nuisance regardless of template content.",
-    )
-    parser.add_argument(
         "--asymImpactsHess",
         default="exact",
         choices=["exact", "hvp", "frozen", "bfgs", "sr1"],
@@ -265,15 +258,6 @@ def make_parser():
         "failures on non-Gaussian profiles -- speed reference only). "
         "'bfgs'/'sr1' use a quasi-Newton estimate built up from the gradient "
         "sequence (no extra TF calls per iteration; may need more iterations).",
-    )
-    parser.add_argument(
-        "--asymImpactsMaxiter",
-        default=200,
-        type=int,
-        help="trust-constr maxiter for the --asymImpacts contour-scan. Lower "
-        "values cap the cost of nuisances that don't converge (useful for "
-        "sanity benchmarks); higher values give genuinely-non-Gaussian "
-        "nuisances more chances to converge.",
     )
     parser.add_argument(
         "--asymImpactsTol",
@@ -667,11 +651,9 @@ def fit(args, fitter, ws, dofit=True):
                 nll_min=fitter.reduced_nll().numpy(),
                 include=args.asymImpactsInclude,
                 exclude=args.asymImpactsExclude,
-                skip_symmetric=not args.asymImpactsAll,
                 hess_mode=args.asymImpactsHess,
                 contour_xtol=args.asymImpactsTol,
                 contour_gtol=args.asymImpactsTol,
-                contour_maxiter=args.asymImpactsMaxiter,
             ),
             base_name="impacts_asym",
         )

--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -227,6 +227,107 @@ def make_parser():
         help="compute impacts of frozen (non-profiled) systematics",
     )
     parser.add_argument(
+        "--asymImpacts",
+        default=False,
+        action="store_true",
+        help="Compute traditional asymmetric impacts on POIs by running a "
+        "Delta(2NLL)=1 contour scan per nuisance. Skips structurally "
+        "symmetric and unconstrained nuisances by default.",
+    )
+    parser.add_argument(
+        "--asymImpactsInclude",
+        default=None,
+        nargs="+",
+        help="Regex(es) restricting which nuisances are scanned for --asymImpacts.",
+    )
+    parser.add_argument(
+        "--asymImpactsExclude",
+        default=None,
+        nargs="+",
+        help="Regex(es) excluding nuisances from --asymImpacts.",
+    )
+    parser.add_argument(
+        "--asymImpactsAll",
+        default=False,
+        action="store_true",
+        help="Disable the structural-symmetric skip in --asymImpacts and scan "
+        "every constrained nuisance regardless of template content.",
+    )
+    parser.add_argument(
+        "--asymImpactsHess",
+        default="exact",
+        choices=["exact", "hvp", "frozen", "bfgs", "sr1"],
+        help="Constraint-Hessian mode for the contour-scan in --asymImpacts. "
+        "'exact' rebuilds the full N x N NLL Hessian each iteration (slow, "
+        "reference). 'hvp' uses Hessian-vector products via a LinearOperator "
+        "(exact, typically fastest for large N). 'frozen' uses cov^-1 from "
+        "the postfit as a constant Hessian (cheapest but produces silent "
+        "failures on non-Gaussian profiles -- speed reference only). "
+        "'bfgs'/'sr1' use a quasi-Newton estimate built up from the gradient "
+        "sequence (no extra TF calls per iteration; may need more iterations).",
+    )
+    parser.add_argument(
+        "--asymImpactsMaxiter",
+        default=200,
+        type=int,
+        help="trust-constr maxiter for the --asymImpacts contour-scan. Lower "
+        "values cap the cost of nuisances that don't converge (useful for "
+        "sanity benchmarks); higher values give genuinely-non-Gaussian "
+        "nuisances more chances to converge.",
+    )
+    parser.add_argument(
+        "--asymImpactsTol",
+        default=1e-6,
+        type=float,
+        help="trust-constr xtol/gtol for the --asymImpacts contour-scan. "
+        "Looser values (e.g. 1e-3) terminate before the iterate is on the "
+        "Delta(2NLL)=q contour, producing silent constraint violations. "
+        "Tighter values (1e-5, 1e-6) are slower with no benefit unless your "
+        "fit has nuisances whose profile is far from quadratic.",
+    )
+    parser.add_argument(
+        "--globalAsymImpacts",
+        default=False,
+        action="store_true",
+        help="Compute fully likelihood-based asymmetric global impacts on POIs "
+        "by shifting each constrained nuisance's theta0 by +/- 1 prefit sigma "
+        "and re-running the fit. In the Gaussian limit this reproduces "
+        "--gaussianGlobalImpacts; deviations measure non-Gaussianity of the "
+        "joint profile. Cost is N_selected x 2 full minimizations -- gate with "
+        "--globalAsymImpactsInclude in practice.",
+    )
+    parser.add_argument(
+        "--globalAsymImpactsInclude",
+        default=None,
+        nargs="+",
+        help="Regex(es) restricting which nuisances are scanned for "
+        "--globalAsymImpacts.",
+    )
+    parser.add_argument(
+        "--globalAsymImpactsExclude",
+        default=None,
+        nargs="+",
+        help="Regex(es) excluding nuisances from --globalAsymImpacts.",
+    )
+    parser.add_argument(
+        "--globalAsymImpactsSigma",
+        default=1.0,
+        type=float,
+        help="theta0 shift magnitude for --globalAsymImpacts, in units of the "
+        "prefit constraint width (1.0 = 1 prefit sigma).",
+    )
+    parser.add_argument(
+        "--globalAsymImpactsLinearWarmstart",
+        default=False,
+        action="store_true",
+        help="EXPERIMENTAL: warm-start each --globalAsymImpacts refit at the "
+        "Gaussian-approximation new minimum x_nom + dxdtheta0[:, i] * shift "
+        "(same Jacobian as --gaussianGlobalImpacts). On near-Gaussian "
+        "nuisances this should reduce per-nuisance refit cost by 10-50x. "
+        "Adds one --gaussianGlobalImpacts-equivalent precompute up front. "
+        "Off by default until validated on real tensors.",
+    )
+    parser.add_argument(
         "--lCurveScan",
         default=False,
         action="store_true",
@@ -558,6 +659,32 @@ def fit(args, fitter, ws, dofit=True):
         # TODO: based on covariance
         ws.add_impacts_asym_hist(
             *fitter.nonprofiled_impacts_parms(), base_name="nonprofiled_impacts_asym"
+        )
+
+    if args.asymImpacts:
+        ws.add_impacts_asym_hist(
+            *fitter.asym_impacts_parms(
+                nll_min=fitter.reduced_nll().numpy(),
+                include=args.asymImpactsInclude,
+                exclude=args.asymImpactsExclude,
+                skip_symmetric=not args.asymImpactsAll,
+                hess_mode=args.asymImpactsHess,
+                contour_xtol=args.asymImpactsTol,
+                contour_gtol=args.asymImpactsTol,
+                contour_maxiter=args.asymImpactsMaxiter,
+            ),
+            base_name="impacts_asym",
+        )
+
+    if args.globalAsymImpacts:
+        ws.add_impacts_asym_hist(
+            *fitter.global_asym_impacts_parms(
+                include=args.globalAsymImpactsInclude,
+                exclude=args.globalAsymImpactsExclude,
+                sigma=args.globalAsymImpactsSigma,
+                linear_warmstart=args.globalAsymImpactsLinearWarmstart,
+            ),
+            base_name="global_impacts_asym",
         )
 
     # Likelihood scans

--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -231,8 +231,8 @@ def make_parser():
         default=False,
         action="store_true",
         help="Compute traditional asymmetric impacts on POIs by running a "
-        "Delta(2NLL)=1 contour scan per nuisance. Skips structurally "
-        "symmetric and unconstrained nuisances by default.",
+        "Delta(2NLL)=1 contour scan per nuisance. All nuisances are scanned "
+        "by default; restrict with --asymImpactsInclude/--asymImpactsExclude.",
     )
     parser.add_argument(
         "--asymImpactsInclude",
@@ -249,7 +249,7 @@ def make_parser():
     parser.add_argument(
         "--asymImpactsHess",
         default="exact",
-        choices=["exact", "hvp", "frozen", "bfgs", "sr1"],
+        choices=fitter.CONTOUR_HESS_MODES,
         help="Constraint-Hessian mode for the contour-scan in --asymImpacts. "
         "'exact' rebuilds the full N x N NLL Hessian each iteration (slow, "
         "reference). 'hvp' uses Hessian-vector products via a LinearOperator "

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -24,6 +24,11 @@ from rabbit.tfhelpers import edmval_cov
 
 logger = logging.child_logger(__name__)
 
+# Supported constraint-Hessian modes for contour_scan (see its docstring for
+# what each mode does). Single source of truth for the CLI choices and the
+# contour_scan validation.
+CONTOUR_HESS_MODES = ("exact", "hvp", "frozen", "bfgs", "sr1")
+
 
 def match_regexp_params(regular_expressions, parameter_names):
     if isinstance(regular_expressions, str):
@@ -1006,7 +1011,6 @@ class Fitter:
         include=None,
         exclude=None,
         skip_symmetric=False,
-        skip_unconstrained=True,
         contour_xtol=1e-6,
         contour_gtol=1e-6,
         contour_maxiter=5000,
@@ -1014,8 +1018,10 @@ class Fitter:
     ):
         """Traditional asymmetric impacts via per-nuisance contour scan.
 
-        All constrained nuisances are scanned by default; use include/exclude
-        to restrict the selection.
+        All nuisances are scanned by default, including unconstrained ones —
+        like the symmetric traditional impacts, the data still gives them a
+        finite postfit uncertainty and hence a finite Delta(2NLL)=q contour.
+        Use include/exclude to restrict the selection.
 
         Args:
             nll_min: postfit reduced NLL. Computed from the current fit state
@@ -1027,19 +1033,14 @@ class Fitter:
                 structurally symmetric (logkhalfdiff identically zero). Off by
                 default since nonlinear effects can produce asymmetric impacts
                 even for symmetric templates.
-            skip_unconstrained: skip nuisances with constraintweight=0 (no
-                finite Delta(2NLL)=q contour).
         """
         if nll_min is None:
             nll_min = float(self.reduced_nll().numpy())
 
         nsyst = self.indata.nsyst
-        cw = self.indata.constraintweights.numpy()
         syst_names = np.array(self.indata.systs).astype(bytes)
 
         selected = np.ones(nsyst, dtype=bool)
-        if skip_unconstrained:
-            selected &= cw > 0
         if skip_symmetric:
             selected &= self.asymmetric_nuisance_mask()
         if include is not None:
@@ -1056,7 +1057,7 @@ class Fitter:
 
         logger.info(
             f"asym_impacts_parms: selected {len(selected_idxs)}/{nsyst} nuisances "
-            f"(skip_symmetric={skip_symmetric}, skip_unconstrained={skip_unconstrained})"
+            f"(skip_symmetric={skip_symmetric})"
         )
 
         return asym_impacts.asym_impacts_parms(
@@ -1075,7 +1076,6 @@ class Fitter:
         self,
         include=None,
         exclude=None,
-        skip_unconstrained=True,
         sigma=1.0,
         linear_warmstart=False,
     ):
@@ -1085,11 +1085,14 @@ class Fitter:
         the prefit constraint width) and re-run the full fit. POI shifts at
         each sign are the asymmetric global impacts.
 
+        Unconstrained nuisances (constraintweight = 0) are always skipped:
+        they have no prefit sigma, and their theta0 does not enter the NLL,
+        so the shifted refit would reproduce the nominal minimum exactly
+        (zero impact at the cost of two full fits).
+
         Args:
             include: optional regex(es) restricting which nuisances to scan.
             exclude: optional regex(es) excluding nuisances from the scan.
-            skip_unconstrained: skip nuisances with constraintweight=0; their
-                "1 prefit sigma" is undefined.
             sigma: shift magnitude in prefit-sigma units.
             linear_warmstart: experimental, see
                 global_asym_impacts.global_asym_impacts_parms.
@@ -1098,9 +1101,9 @@ class Fitter:
         cw = self.indata.constraintweights.numpy()
         syst_names = np.array(self.indata.systs).astype(bytes)
 
-        selected = np.ones(nsyst, dtype=bool)
-        if skip_unconstrained:
-            selected &= cw > 0
+        # theta0 of an unconstrained nuisance does not enter the NLL: no
+        # finite prefit sigma to shift by, and the refit would be a no-op.
+        selected = cw > 0
         if include is not None:
             keep = match_regexp_params(include, syst_names)
             keep_set = set(keep)
@@ -1115,7 +1118,7 @@ class Fitter:
 
         logger.info(
             f"global_asym_impacts_parms: selected {len(selected_idxs)}/{nsyst} "
-            f"nuisances (skip_unconstrained={skip_unconstrained})"
+            f"nuisances (unconstrained nuisances always excluded)"
         )
 
         return global_asym_impacts.global_asym_impacts_parms(
@@ -2359,7 +2362,7 @@ class Fitter:
         else:
             raise ValueError(
                 f"contour_scan: unknown hess_mode={hess_mode!r}; "
-                "expected one of 'exact', 'hvp', 'frozen', 'bfgs', 'sr1'."
+                f"expected one of {CONTOUR_HESS_MODES}."
             )
 
         def scipy_loss(x):

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -1005,14 +1005,17 @@ class Fitter:
         q=1,
         include=None,
         exclude=None,
-        skip_symmetric=True,
+        skip_symmetric=False,
         skip_unconstrained=True,
         contour_xtol=1e-6,
         contour_gtol=1e-6,
-        contour_maxiter=200,
+        contour_maxiter=5000,
         hess_mode="exact",
     ):
         """Traditional asymmetric impacts via per-nuisance contour scan.
+
+        All constrained nuisances are scanned by default; use include/exclude
+        to restrict the selection.
 
         Args:
             nll_min: postfit reduced NLL. Computed from the current fit state
@@ -1020,8 +1023,10 @@ class Fitter:
             q: contour level (q=1 -> 1 sigma).
             include: optional regex(es) restricting which nuisances to scan.
             exclude: optional regex(es) excluding nuisances from the scan.
-            skip_symmetric: skip nuisances whose template content is structurally
-                symmetric (their asymmetric impact equals the Gaussian impact).
+            skip_symmetric: optionally skip nuisances whose template content is
+                structurally symmetric (logkhalfdiff identically zero). Off by
+                default since nonlinear effects can produce asymmetric impacts
+                even for symmetric templates.
             skip_unconstrained: skip nuisances with constraintweight=0 (no
                 finite Delta(2NLL)=q contour).
         """
@@ -2267,7 +2272,7 @@ class Fitter:
         fun=None,
         xtol=1e-6,
         gtol=1e-6,
-        maxiter=200,
+        maxiter=5000,
         hess_mode="exact",
     ):
         # Layered cache: trust-constr calls scipy_loss many times during line

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -13,7 +13,13 @@ from wums import logging
 from rabbit import external_likelihood, io_tools
 from rabbit import tfhelpers as tfh
 from rabbit.bbstat.bbstat import BinByBinStat
-from rabbit.impacts import global_impacts, nonprofiled_impacts, traditional_impacts
+from rabbit.impacts import (
+    asym_impacts,
+    global_asym_impacts,
+    global_impacts,
+    nonprofiled_impacts,
+    traditional_impacts,
+)
 from rabbit.tfhelpers import edmval_cov
 
 logger = logging.child_logger(__name__)
@@ -537,7 +543,17 @@ class Fitter:
     def get_model_nui(self):
         npoi = self.param_model.npoi
         npou = self.param_model.npou
-        return self.x[npoi : npoi + npou]
+        nui = self.x[npoi : npoi + npou]
+        # Apply frozen_params_mask the same way get_poi() and get_theta() do.
+        # Without this, --freezeParameters silently fails to freeze POUs:
+        # the param is registered as frozen but no stop_gradient is applied,
+        # so the optimizer updates it anyway.
+        nui = tf.where(
+            self.frozen_params_mask[npoi : npoi + npou],
+            tf.stop_gradient(nui),
+            nui,
+        )
+        return nui
 
     def get_poi(self):
         xpoi = self.x[: self.param_model.npoi]
@@ -858,6 +874,47 @@ class Fitter:
 
         return edmval, cov_rows
 
+    def _resolved_param_impact_groups(self):
+        """
+        ParamModel impact groups resolved to floating full-x parameter indices.
+        """
+        groups = getattr(self.param_model, "param_impact_groups", None)
+        if not groups:
+            return []
+        parms = self.parms.astype(str)
+        name_to_idx = {p: i for i, p in enumerate(parms)}
+        frozen = set(int(i) for i in np.atleast_1d(self.frozen_indices))
+        resolved = []
+        for label, pnames in groups.items():
+            idxs = [
+                name_to_idx[p]
+                for p in pnames
+                if p in name_to_idx and name_to_idx[p] not in frozen
+            ]
+            if idxs:
+                resolved.append((label, np.array(idxs, dtype=np.int32)))
+        return resolved
+
+    def _cov_stat_floating(self, hess, nstat):
+        """
+        Invert the stat sub-Hessian hess[:nstat, :nstat], excluding frozen params.
+        """
+        hess_stat = hess[:nstat, :nstat]
+        if len(self.frozen_params) == 0:
+            return tf.linalg.inv(hess_stat)
+        stat_float = self.floating_indices[self.floating_indices < nstat]
+        sub = tf.gather(tf.gather(hess_stat, stat_float, axis=0), stat_float, axis=1)
+        sub_inv = tf.linalg.inv(sub)
+        coords = tf.reshape(
+            tf.stack(tf.meshgrid(stat_float, stat_float, indexing="ij"), axis=-1),
+            [-1, 2],
+        )
+        return tf.scatter_nd(
+            tf.cast(coords, tf.int64),
+            tf.reshape(sub_inv, [-1]),
+            tf.constant([nstat, nstat], dtype=tf.int64),
+        )
+
     @tf.function
     def impacts_parms(self, hess):
 
@@ -866,18 +923,17 @@ class Fitter:
             + self.param_model.npou
             + self.indata.nsystnoconstraint
         )
-        hess_stat = hess[:nstat, :nstat]
-        cov_stat = tf.linalg.inv(hess_stat)
+        cov_stat = self._cov_stat_floating(hess, nstat)
 
         if self.bbstat.enabled:
             val_no_bbb, grad_no_bbb, hess_no_bbb = self.loss_val_grad_hess(
                 profile=False
             )
-            hess_stat_no_bbb = hess_no_bbb[:nstat, :nstat]
-            cov_stat_no_bbb = tf.linalg.inv(hess_stat_no_bbb)
+            cov_stat_no_bbb = self._cov_stat_floating(hess_no_bbb, nstat)
         else:
             cov_stat_no_bbb = None
 
+        param_groups = self._resolved_param_impact_groups()
         impacts, impacts_grouped = traditional_impacts.impacts_parms(
             self.cov,
             cov_stat,
@@ -885,6 +941,8 @@ class Fitter:
             self.param_model.npoi,
             self.indata.noiidxs,
             self.indata.systgroupidxs,
+            nmodel_params=self.param_model.npoi + self.param_model.npou,
+            param_groupidxs=[idxs for _, idxs in param_groups],
         )
 
         return impacts, impacts_grouped
@@ -935,6 +993,133 @@ class Fitter:
         )
 
         return impacts, impacts_grouped
+
+    def asymmetric_nuisance_mask(self, atol=0.0):
+        """Boolean mask of length nsyst, True where the nuisance has nonzero
+        asymmetric (logkhalfdiff) tensor content."""
+        return asym_impacts.asymmetric_nuisance_mask(self.indata, atol=atol)
+
+    def asym_impacts_parms(
+        self,
+        nll_min=None,
+        q=1,
+        include=None,
+        exclude=None,
+        skip_symmetric=True,
+        skip_unconstrained=True,
+        contour_xtol=1e-6,
+        contour_gtol=1e-6,
+        contour_maxiter=200,
+        hess_mode="exact",
+    ):
+        """Traditional asymmetric impacts via per-nuisance contour scan.
+
+        Args:
+            nll_min: postfit reduced NLL. Computed from the current fit state
+                if None.
+            q: contour level (q=1 -> 1 sigma).
+            include: optional regex(es) restricting which nuisances to scan.
+            exclude: optional regex(es) excluding nuisances from the scan.
+            skip_symmetric: skip nuisances whose template content is structurally
+                symmetric (their asymmetric impact equals the Gaussian impact).
+            skip_unconstrained: skip nuisances with constraintweight=0 (no
+                finite Delta(2NLL)=q contour).
+        """
+        if nll_min is None:
+            nll_min = float(self.reduced_nll().numpy())
+
+        nsyst = self.indata.nsyst
+        cw = self.indata.constraintweights.numpy()
+        syst_names = np.array(self.indata.systs).astype(bytes)
+
+        selected = np.ones(nsyst, dtype=bool)
+        if skip_unconstrained:
+            selected &= cw > 0
+        if skip_symmetric:
+            selected &= self.asymmetric_nuisance_mask()
+        if include is not None:
+            keep = match_regexp_params(include, syst_names)
+            keep_set = set(keep)
+            selected &= np.array([n in keep_set for n in syst_names])
+        if exclude is not None:
+            drop = match_regexp_params(exclude, syst_names)
+            drop_set = set(drop)
+            selected &= np.array([n not in drop_set for n in syst_names])
+
+        selected_idxs = np.where(selected)[0]
+        selected_names = syst_names[selected_idxs]
+
+        logger.info(
+            f"asym_impacts_parms: selected {len(selected_idxs)}/{nsyst} nuisances "
+            f"(skip_symmetric={skip_symmetric}, skip_unconstrained={skip_unconstrained})"
+        )
+
+        return asym_impacts.asym_impacts_parms(
+            self,
+            nll_min,
+            selected_idxs,
+            selected_names,
+            q=q,
+            contour_xtol=contour_xtol,
+            contour_gtol=contour_gtol,
+            contour_maxiter=contour_maxiter,
+            hess_mode=hess_mode,
+        )
+
+    def global_asym_impacts_parms(
+        self,
+        include=None,
+        exclude=None,
+        skip_unconstrained=True,
+        sigma=1.0,
+        linear_warmstart=False,
+    ):
+        """Fully likelihood-based asymmetric global impacts.
+
+        For each selected nuisance i, shift theta0[i] by +/- sigma (in units of
+        the prefit constraint width) and re-run the full fit. POI shifts at
+        each sign are the asymmetric global impacts.
+
+        Args:
+            include: optional regex(es) restricting which nuisances to scan.
+            exclude: optional regex(es) excluding nuisances from the scan.
+            skip_unconstrained: skip nuisances with constraintweight=0; their
+                "1 prefit sigma" is undefined.
+            sigma: shift magnitude in prefit-sigma units.
+            linear_warmstart: experimental, see
+                global_asym_impacts.global_asym_impacts_parms.
+        """
+        nsyst = self.indata.nsyst
+        cw = self.indata.constraintweights.numpy()
+        syst_names = np.array(self.indata.systs).astype(bytes)
+
+        selected = np.ones(nsyst, dtype=bool)
+        if skip_unconstrained:
+            selected &= cw > 0
+        if include is not None:
+            keep = match_regexp_params(include, syst_names)
+            keep_set = set(keep)
+            selected &= np.array([n in keep_set for n in syst_names])
+        if exclude is not None:
+            drop = match_regexp_params(exclude, syst_names)
+            drop_set = set(drop)
+            selected &= np.array([n not in drop_set for n in syst_names])
+
+        selected_idxs = np.where(selected)[0]
+        selected_names = syst_names[selected_idxs]
+
+        logger.info(
+            f"global_asym_impacts_parms: selected {len(selected_idxs)}/{nsyst} "
+            f"nuisances (skip_unconstrained={skip_unconstrained})"
+        )
+
+        return global_asym_impacts.global_asym_impacts_parms(
+            self,
+            selected_idxs,
+            selected_names,
+            sigma=sigma,
+            linear_warmstart=linear_warmstart,
+        )
 
     def nonprofiled_impacts_parms(self, unconstrained_err=1.0):
         return nonprofiled_impacts.nonprofiled_impacts_parms(
@@ -2073,23 +2258,112 @@ class Fitter:
 
         return x_scans, y_scans, dnlls
 
-    def contour_scan(self, param, nll_min, q=1, signs=[-1, 1], fun=None):
-        # TODO this is basically traditional asymmetric impacts
-        def scipy_loss(x):
-            self.x.assign(x)
-            val = self.loss_val()
-            loss = val.numpy() - nll_min - 0.5 * q
-            return loss[None,]
+    def contour_scan(
+        self,
+        param,
+        nll_min,
+        q=1,
+        signs=[-1, 1],
+        fun=None,
+        xtol=1e-6,
+        gtol=1e-6,
+        maxiter=200,
+        hess_mode="exact",
+    ):
+        # Layered cache: trust-constr calls scipy_loss many times during line
+        # search (only val needed), and scipy_grad / scipy_hess on accepted
+        # steps. The cache is keyed by x content so repeated requests at the
+        # same point are free.
+        lg_cache = {"x": None, "val": None, "grad": None}
 
-        def scipy_grad(x):
+        def _ensure_loss_grad(x):
+            if lg_cache["x"] is not None and np.array_equal(lg_cache["x"], x):
+                return
             self.x.assign(x)
             val, grad = self.loss_val_grad()
-            return grad.numpy()[None,]
+            lg_cache["x"] = np.array(x, copy=True)
+            lg_cache["val"] = float(val.numpy()) - nll_min - 0.5 * q
+            lg_cache["grad"] = grad.numpy()
 
-        def scipy_hess(x, v):
-            self.x.assign(x)
-            val, grad, hess = self.loss_val_grad_hess()
-            return v[0] * hess.numpy()
+        # Constraint Hessian. Modes:
+        #   "exact": recompute the full NLL Hessian at every accepted iteration
+        #       (~25 s/eval for thousands of params; dominant cost). Reference.
+        #   "hvp": LinearOperator whose matvec computes one Hessian-vector
+        #       product via a nested GradientTape (~2x the cost of a gradient).
+        #       Exact (no approximation); avoids materializing the N x N matrix.
+        #       trust-constr only multiplies H against trial directions in its
+        #       inner CG, so HVP is typically much faster than "exact".
+        #   "frozen": constant Hessian = postfit precision matrix (cov^-1),
+        #       computed once. Cheapest, but the Lagrangian model is wrong off
+        #       the postfit, so trust-constr's KKT/optimality criterion can be
+        #       satisfied while the constraint violation is large -- producing
+        #       silent failures on non-Gaussian profiles. Useful only as a
+        #       speed reference, not as a production default.
+        #   "bfgs" / "sr1": quasi-Newton Hessian estimate built up by
+        #       trust-constr from the gradient sequence (no extra TF calls).
+        #       Cheapest per iteration; may need more iterations to converge.
+        #       SR1 is more robust for non-convex local geometry than BFGS.
+        if hess_mode == "hvp":
+
+            def scipy_hess(x, v):
+                _ensure_loss_grad(x)
+                n = len(x)
+                scale = float(v[0])
+
+                def _matvec(p):
+                    self.x.assign(x)
+                    p_tf = tf.convert_to_tensor(p, dtype=self.indata.dtype)
+                    _, _, hp = self.loss_val_grad_hessp(p_tf)
+                    return scale * hp.numpy()
+
+                return scipy.sparse.linalg.LinearOperator(
+                    shape=(n, n), matvec=_matvec, dtype=np.float64
+                )
+
+        elif hess_mode == "frozen":
+            postfit_hess = np.linalg.inv(self.cov.numpy())
+
+            def scipy_hess(x, v):
+                return v[0] * postfit_hess
+
+        elif hess_mode == "bfgs":
+            scipy_hess = scipy.optimize.BFGS()
+
+        elif hess_mode == "sr1":
+            scipy_hess = scipy.optimize.SR1()
+
+        elif hess_mode == "exact":
+            h_cache = {"x": None, "hess": None}
+
+            def _ensure_hess(x):
+                if h_cache["x"] is not None and np.array_equal(h_cache["x"], x):
+                    return
+                self.x.assign(x)
+                val, grad, hess = self.loss_val_grad_hess()
+                h_cache["x"] = np.array(x, copy=True)
+                h_cache["hess"] = hess.numpy()
+                # opportunistically refresh the loss/grad cache.
+                lg_cache["x"] = h_cache["x"]
+                lg_cache["val"] = float(val.numpy()) - nll_min - 0.5 * q
+                lg_cache["grad"] = grad.numpy()
+
+            def scipy_hess(x, v):
+                _ensure_hess(x)
+                return v[0] * h_cache["hess"]
+
+        else:
+            raise ValueError(
+                f"contour_scan: unknown hess_mode={hess_mode!r}; "
+                "expected one of 'exact', 'hvp', 'frozen', 'bfgs', 'sr1'."
+            )
+
+        def scipy_loss(x):
+            _ensure_loss_grad(x)
+            return np.array([lg_cache["val"]])
+
+        def scipy_grad(x):
+            _ensure_loss_grad(x)
+            return lg_cache["grad"][None, :]
 
         nlc = scipy.optimize.NonlinearConstraint(
             fun=scipy_loss,
@@ -2103,30 +2377,24 @@ class Fitter:
         params_values = np.full((len(signs), len(self.parms)), np.nan)
 
         xval = tf.identity(self.x)
-        xval_init = xval.numpy()
+        xval_np = xval.numpy()
 
         idx = np.where(self.parms.astype(str) == param)[0][0]
-        x0 = xval[idx]
+        x0 = xval_np[idx]
 
-        # initial guess from covariance
-        initial_fit = False
-
-        xup = xval[idx] + (self.cov[idx, idx] * q) ** 0.5
-        xdn = xval[idx] - (self.cov[idx, idx] * q) ** 0.5
+        # Gaussian-optimal warm start on the Delta(2NLL)=q contour:
+        # maximizing +/- dx[idx] subject to dx^T H dx = q (with H = cov^{-1})
+        # gives dx = sign * sqrt(q) * cov[:,idx] / sqrt(cov[idx,idx]).
+        # This lands all parameters on the contour in the Gaussian limit and
+        # is exact for nuisances with a near-quadratic likelihood, so the
+        # constrained minimization typically converges in just a few steps.
+        cov_col = self.cov[:, idx].numpy()
+        sigma_idx = float(self.cov[idx, idx].numpy()) ** 0.5
+        gauss_dx = (q**0.5) * cov_col / sigma_idx
 
         for i, sign in enumerate(signs):
-            # Objective function and its derivatives
-            if sign == -1:
-                xval_init[idx] = xdn
-            else:
-                xval_init[idx] = xup
-
-            if initial_fit:
-                # perform initial fit where contour is expected
-                self.x.assign(xval_init)
-                self.freeze_params(param)
-                self.minimize()
-                self.defreeze_params(param)
+            xval_init = xval_np + sign * gauss_dx
+            t_side0 = time.perf_counter()
 
             opt = {}
             if fun is None:
@@ -2189,20 +2457,27 @@ class Fitter:
                 jac=True,
                 constraints=[nlc],
                 options={
-                    "maxiter": 50000,
-                    "xtol": 1e-10,
-                    "gtol": 1e-10,
-                    # "barrier_tol": 1e-10,
+                    "maxiter": maxiter,
+                    "xtol": xtol,
+                    "gtol": gtol,
                 },
                 **opt,
             )
 
-            logger.info(f"Success: {res.success}")
+            t_side = time.perf_counter() - t_side0
+            logger.info(
+                f"Success: {res.success} sign={sign} time={t_side:.2f}s "
+                f"(nit={getattr(res, 'nit', '?')}, "
+                f"nfev={getattr(res, 'nfev', '?')}, "
+                f"njev={getattr(res, 'njev', '?')}, "
+                f"nhev={getattr(res, 'nhev', '?')})"
+            )
             logger.debug(f"Status: {res.status}")
             if not res.success:
                 logger.warning(f"Message: {res.message}")
                 logger.warning(f"Optimality (gtol): {res.optimality}")
                 logger.warning(f"Constraint Violation: {res.constr_violation}")
+                self.x.assign(xval)
                 continue
 
             params_values[i] = res["x"] - xval

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -1060,11 +1060,26 @@ class Fitter:
             f"(skip_symmetric={skip_symmetric})"
         )
 
+        # freeze-group grouped impacts are computed for the POIs and NOIs
+        npoi = self.param_model.npoi
+        targets = [
+            p.decode() if isinstance(p, bytes) else str(p)
+            for p in self.param_model.params[:npoi]
+        ] + [
+            (
+                self.indata.systs[i].decode()
+                if isinstance(self.indata.systs[i], bytes)
+                else str(self.indata.systs[i])
+            )
+            for i in self.indata.noiidxs
+        ]
+
         return asym_impacts.asym_impacts_parms(
             self,
             nll_min,
             selected_idxs,
             selected_names,
+            targets=targets,
             q=q,
             contour_xtol=contour_xtol,
             contour_gtol=contour_gtol,
@@ -2399,6 +2414,12 @@ class Fitter:
         cov_col = self.cov[:, idx].numpy()
         sigma_idx = float(self.cov[idx, idx].numpy()) ** 0.5
         gauss_dx = (q**0.5) * cov_col / sigma_idx
+        # Frozen parameters must stay at their current values: their gradients
+        # are masked, so the optimizer would never move them back, and a
+        # displaced frozen parameter shifts the NLL value and biases the
+        # contour. Zero their warm-start displacement.
+        if len(self.frozen_indices):
+            gauss_dx[self.frozen_indices] = 0.0
 
         for i, sign in enumerate(signs):
             xval_init = xval_np + sign * gauss_dx

--- a/rabbit/impacts/asym_impacts.py
+++ b/rabbit/impacts/asym_impacts.py
@@ -1,0 +1,168 @@
+"""
+Traditional asymmetric impacts.
+
+For each selected nuisance, find the asymmetric +/- 1 sigma points on the
+Delta(2NLL)=q likelihood contour via constrained minimization (contour_scan).
+The shifts of every fitter parameter at those points are the asymmetric
+impacts. Group impacts are obtained by quadrature envelope of the contained
+nuisances, separately for the down and up sides.
+
+Nuisances that are structurally symmetric (logkhalfdiff identically zero)
+or unconstrained (constraintweight = 0) are skipped by default: the first
+case has asymmetric impact equal to the Gaussian impact (already produced by
+traditional_impacts.impacts_parms), and the second has no finite Delta(2NLL)
+contour.
+"""
+
+import time
+
+import numpy as np
+from wums import logging
+
+logger = logging.child_logger(__name__)
+
+
+def asymmetric_nuisance_mask(indata, atol=0.0):
+    """Boolean mask of length nsyst, True for nuisances with nonzero asymmetric
+    (logkhalfdiff) tensor content. False if the entire tensor is symmetric or
+    if a particular nuisance has zero halfdiff."""
+    if indata.symmetric_tensor:
+        return np.zeros(indata.nsyst, dtype=bool)
+
+    nsyst = indata.nsyst
+    if indata.sparse:
+        idx = indata.logk.indices.numpy()
+        vals = indata.logk.values.numpy()
+        syst_col = idx[:, -1]
+        halfdiff_entries = (syst_col >= nsyst) & (np.abs(vals) > atol)
+        nz_systs = np.unique(syst_col[halfdiff_entries]) - nsyst
+        mask = np.zeros(nsyst, dtype=bool)
+        mask[nz_systs] = True
+        return mask
+
+    # Dense layout: logk has shape [nbinsfull, nproc, 2, nsyst] when asymmetric;
+    # axis -2 is [logkavg, logkhalfdiff]. Reduce over (bin, proc) for halfdiff.
+    halfdiff = indata.logk[..., 1, :].numpy()
+    axes = tuple(range(halfdiff.ndim - 1))
+    return np.any(np.abs(halfdiff) > atol, axis=axes)
+
+
+def _envelope(values):
+    """Quadrature envelope of asymmetric impacts within a group.
+
+    Args:
+        values: numpy array of shape (n_in_group, 2, n_total_params), where
+            axis 1 is [down, up].
+
+    Returns:
+        Array of shape (2, n_total_params) with the envelope's lower (negative)
+        and upper (positive) sides.
+    """
+    zeros = np.zeros((values.shape[0], values.shape[-1]), dtype=values.dtype)
+    vmin = np.min(values, axis=1)
+    vmax = np.max(values, axis=1)
+    lower = -np.sqrt(np.sum(np.minimum(zeros, vmin) ** 2, axis=0))
+    upper = np.sqrt(np.sum(np.maximum(zeros, vmax) ** 2, axis=0))
+    return np.stack([lower, upper])
+
+
+def asym_impacts_parms(
+    fitter,
+    nll_min,
+    selected_idxs,
+    selected_names,
+    q=1,
+    contour_xtol=1e-4,
+    contour_gtol=1e-4,
+    contour_maxiter=200,
+    hess_mode="exact",
+):
+    """Run a per-nuisance contour scan and assemble the asymmetric-impact tensor.
+
+    Args:
+        fitter: the Fitter instance (used for contour_scan and indata).
+        nll_min: postfit reduced NLL.
+        selected_idxs: indices into the syst axis (0..nsyst-1) of nuisances to scan.
+        selected_names: names of those nuisances (bytes), used as impact-axis labels.
+        q: contour level (q=1 -> 1 sigma, q=4 -> 2 sigma).
+
+    Returns:
+        parms: np.ndarray of bytes, the impact-axis labels.
+        impacts: np.ndarray of shape (n_scanned, 2, n_total_params).
+            Axis 1 is [down, up] matching axis_downUpVar.
+        group_names: np.ndarray of bytes for groups containing scanned nuisances
+            (plus a trailing "Total").
+        impacts_grouped: np.ndarray of shape (n_groups, 2, n_total_params).
+    """
+    n_scanned = len(selected_idxs)
+    n_total = len(fitter.parms)
+    impacts = np.zeros((n_scanned, 2, n_total))
+
+    logger.info(f"asym_impacts: scanning {n_scanned} nuisances")
+
+    t_per = np.zeros(n_scanned, dtype=np.float64)
+    t_total0 = time.perf_counter()
+
+    for i, name in enumerate(selected_names):
+        name_str = name.decode() if isinstance(name, bytes) else name
+        logger.info(f"  [{i + 1}/{n_scanned}] contour scan for {name_str}")
+        t0 = time.perf_counter()
+        _, params_values = fitter.contour_scan(
+            name_str,
+            nll_min,
+            q=q,
+            signs=[-1, 1],
+            xtol=contour_xtol,
+            gtol=contour_gtol,
+            maxiter=contour_maxiter,
+            hess_mode=hess_mode,
+        )
+        t_per[i] = time.perf_counter() - t0
+        logger.info(f"    took {t_per[i]:.2f}s")
+        # signs=[-1, +1] -> bin 0 = down, bin 1 = up (matches axis_downUpVar).
+        # params_values rows are NaN where convergence failed; leave as zero impact.
+        if not np.any(np.isnan(params_values)):
+            impacts[i] = params_values
+        else:
+            valid = ~np.any(np.isnan(params_values), axis=1)
+            impacts[i, valid] = params_values[valid]
+
+    if n_scanned > 0:
+        t_total = time.perf_counter() - t_total0
+        logger.info(
+            f"asym_impacts: total {t_total:.1f}s "
+            f"(mean {t_per.mean():.2f}s, min {t_per.min():.2f}s, "
+            f"max {t_per.max():.2f}s per nuisance)"
+        )
+
+    # Build grouped impacts via quadrature envelope, separately for down/up.
+    syst_names = np.array(fitter.indata.systs).astype(bytes)
+    selected_set = set(selected_idxs.tolist())
+    pos_in_scanned = {int(idx): k for k, idx in enumerate(selected_idxs)}
+
+    group_names = []
+    group_impacts = []
+    for gname, gidxs in zip(fitter.indata.systgroups, fitter.indata.systgroupidxs):
+        gidxs = np.asarray(gidxs).astype(int)
+        in_scanned = [pos_in_scanned[i] for i in gidxs if int(i) in selected_set]
+        if not in_scanned:
+            continue
+        sub = impacts[in_scanned]
+        group_names.append(gname)
+        group_impacts.append(_envelope(sub))
+
+    if n_scanned > 0:
+        group_names.append(b"Total")
+        group_impacts.append(_envelope(impacts))
+
+    if group_impacts:
+        impacts_grouped = np.stack(group_impacts)
+    else:
+        impacts_grouped = np.zeros((0, 2, n_total))
+
+    return (
+        np.asarray(selected_names),
+        impacts,
+        np.asarray(group_names),
+        impacts_grouped,
+    )

--- a/rabbit/impacts/asym_impacts.py
+++ b/rabbit/impacts/asym_impacts.py
@@ -7,11 +7,12 @@ The shifts of every fitter parameter at those points are the asymmetric
 impacts. Group impacts are obtained by quadrature envelope of the contained
 nuisances, separately for the down and up sides.
 
-Nuisances that are structurally symmetric (logkhalfdiff identically zero)
-or unconstrained (constraintweight = 0) are skipped by default: the first
-case has asymmetric impact equal to the Gaussian impact (already produced by
-traditional_impacts.impacts_parms), and the second has no finite Delta(2NLL)
-contour.
+All constrained nuisances are scanned by default (nonlinear effects can
+produce asymmetric impacts even for structurally symmetric templates);
+use include/exclude to restrict the selection. Unconstrained nuisances
+(constraintweight = 0) are skipped since they have no finite Delta(2NLL)
+contour. An optional structural-symmetry skip (logkhalfdiff identically
+zero) is available programmatically via skip_symmetric.
 """
 
 import time
@@ -74,7 +75,7 @@ def asym_impacts_parms(
     q=1,
     contour_xtol=1e-4,
     contour_gtol=1e-4,
-    contour_maxiter=200,
+    contour_maxiter=5000,
     hess_mode="exact",
 ):
     """Run a per-nuisance contour scan and assemble the asymmetric-impact tensor.

--- a/rabbit/impacts/asym_impacts.py
+++ b/rabbit/impacts/asym_impacts.py
@@ -4,10 +4,17 @@ Traditional asymmetric impacts.
 For each selected nuisance, find the asymmetric +/- 1 sigma points on the
 Delta(2NLL)=q likelihood contour via constrained minimization (contour_scan).
 The shifts of every fitter parameter at those points are the asymmetric
-impacts. Group impacts follow the traditional grouped-impact convention,
-generalized to the asymmetric case: per side, sqrt(delta^T rho_GG^-1 delta)
-over the group's scanned nuisances, with rho_GG the postfit correlation
-submatrix (see _group_impact).
+impacts.
+
+Group impacts use the freeze-group convention (as in combine): for each
+POI/NOI target, scan its own Delta(2NLL)=q contour with nothing frozen
+(total interval), then once more per group with the group's nuisances frozen
+at their postfit values; per side the group impact is the quadrature
+difference sqrt(sigma_tot^2 - sigma_frozen^2). Both intervals come from full
+profile likelihoods, so all correlations within the group and with the rest
+of the fit are accounted for. The "stat" column is the interval with every
+constrained nuisance frozen (reported directly, not subtracted), and "Total"
+is the unfrozen interval itself.
 
 All nuisances are scanned by default, including unconstrained ones — like
 the symmetric traditional impacts, the data still gives them a finite
@@ -51,50 +58,138 @@ def asymmetric_nuisance_mask(indata, atol=0.0):
     return np.any(np.abs(halfdiff) > atol, axis=axes)
 
 
-def _group_impact(values, rho_inv):
-    """Correlation-aware group combination of asymmetric impacts.
+def _scan_interval(fitter, target, nll_min, q, scan_kwargs):
+    """Signed [down, up] Delta(2NLL)=q interval of a single parameter from its
+    contour scan. Entries are NaN where the scan did not converge."""
+    intervals, _ = fitter.contour_scan(
+        target, nll_min, q=q, signs=[-1, 1], **scan_kwargs
+    )
+    return np.asarray(intervals, dtype=np.float64)
 
-    Asymmetric analogue of the traditional grouped-impact convention
-    (sqrt(v^T C_GG^-1 v) in traditional_impacts._compute_impact_group):
-    per side s, the group impact on each parameter is
 
-        sqrt( delta_s^T rho_GG^-1 delta_s )
+def _quad_subtract(tot, frozen):
+    """Per-side quadrature difference of two signed [down, up] intervals.
 
-    where delta_s is the vector of per-nuisance impacts on that parameter at
-    the side-s contour points and rho_GG is the postfit correlation submatrix
-    of the group's nuisances. In the symmetric Gaussian limit
-    (delta_j = cov[i, j] / sqrt(cov[j, j])) this reproduces the traditional
-    grouped impact exactly; for uncorrelated nuisances it reduces to a
-    quadrature sum.
+    Returns signed [down, up] with down <= 0 <= up. The argument of the sqrt
+    is clipped at zero: freezing parameters can only shrink the profile
+    interval in the Gaussian limit, so a (small) negative difference is
+    numerical noise from the scan tolerances; a large one indicates an
+    unconverged scan and is logged.
+    """
+    out = np.full(2, np.nan)
+    for s in range(2):
+        if not (np.isfinite(tot[s]) and np.isfinite(frozen[s])):
+            continue
+        diff = tot[s] ** 2 - frozen[s] ** 2
+        if diff < -0.05 * tot[s] ** 2:
+            logger.warning(
+                f"freeze-group quadrature difference is significantly "
+                f"negative (tot={tot[s]:.4g}, frozen={frozen[s]:.4g}); "
+                f"likely an unconverged contour scan. Clipping to 0."
+            )
+        mag = np.sqrt(max(diff, 0.0))
+        out[s] = -mag if s == 0 else mag
+    return out
+
+
+def grouped_asym_impacts(
+    fitter,
+    nll_min,
+    targets,
+    q=1,
+    scan_kwargs=None,
+):
+    """Freeze-group grouped asymmetric impacts (combine convention).
+
+    For each target parameter (POIs and NOIs), the asymmetric Delta(2NLL)=q
+    interval is scanned with nothing frozen (total) and once per nuisance
+    group with the group's members frozen at their postfit values; the group
+    impact per side is sqrt(sigma_tot^2 - sigma_frozen^2). The "stat" column
+    is the interval with all constrained nuisances frozen (reported directly),
+    "Total" is the unfrozen interval. Note the bin-by-bin stat beta
+    parameters remain profiled throughout, so "stat" includes the
+    bin-by-bin MC-stat contribution (stat (+) binByBinStat in the
+    traditional grouped-impact decomposition).
 
     Args:
-        values: numpy array of shape (n_in_group, 2, n_total_params), where
-            axis 1 is [down, up].
-        rho_inv: numpy array of shape (n_in_group, n_in_group), the inverse
-            postfit correlation matrix of the group's nuisances.
+        fitter: the Fitter instance.
+        nll_min: postfit reduced NLL.
+        targets: list of parameter names (str) to compute group impacts for.
+        q: contour level (q=1 -> 1 sigma).
+        scan_kwargs: forwarded to contour_scan (xtol/gtol/maxiter/hess_mode).
 
     Returns:
-        Array of shape (2, n_total_params) with the group's lower (negative)
-        and upper (positive) sides.
+        group_names: np.ndarray of bytes, [systgroups..., stat, Total].
+        impacts_grouped: np.ndarray of shape (n_groups, 2, n_total_params),
+            NaN outside the target columns.
     """
-    down = values[:, 0, :]
-    up = values[:, 1, :]
-    # rho_inv is positive-definite so the quadratic form is >= 0; the clip
-    # only guards against floating-point round-off.
-    q_down = np.einsum("jt,jk,kt->t", down, rho_inv, down)
-    q_up = np.einsum("jt,jk,kt->t", up, rho_inv, up)
-    lower = -np.sqrt(np.clip(q_down, 0.0, None))
-    upper = np.sqrt(np.clip(q_up, 0.0, None))
-    return np.stack([lower, upper])
+    scan_kwargs = scan_kwargs or {}
+    n_total = len(fitter.parms)
+    parms_str = fitter.parms.astype(str)
+    target_cols = {t: int(np.where(parms_str == t)[0][0]) for t in targets}
+    syst_names_str = np.array(fitter.indata.systs).astype(str)
+    # only freeze what this function froze; never defreeze user-frozen params
+    already_frozen = {
+        p.decode() if isinstance(p, bytes) else str(p) for p in fitter.frozen_params
+    }
 
+    n_groups = len(fitter.indata.systgroups)
+    n_scans = len(targets) * (n_groups + 2) * 2
+    logger.info(
+        f"grouped asym impacts (freeze-group): {len(targets)} targets x "
+        f"({n_groups} groups + stat + Total) -> {n_scans} contour scans"
+    )
+    t0 = time.perf_counter()
 
-def _rho_inv_for(cov, x_idxs):
-    """Inverse postfit correlation submatrix for the given full-x indices."""
-    sub = cov[np.ix_(x_idxs, x_idxs)]
-    sigma = np.sqrt(np.diag(sub))
-    rho = sub / np.outer(sigma, sigma)
-    # pinv for robustness against near-degenerate (highly correlated) groups.
-    return np.linalg.pinv(rho)
+    # total (unfrozen) interval per target
+    totals = {t: _scan_interval(fitter, t, nll_min, q, scan_kwargs) for t in targets}
+
+    def scan_with_frozen(members):
+        """Scan all targets with the given nuisances (str names) frozen at
+        their postfit values."""
+        to_freeze = [m for m in members if m not in already_frozen]
+        arr = np.full((2, n_total), np.nan)
+        if to_freeze:
+            fitter.freeze_params(to_freeze)
+        try:
+            frozen_set = set(members) | already_frozen
+            for t, c in target_cols.items():
+                if t in frozen_set:
+                    continue  # cannot scan a frozen target
+                arr[:, c] = _scan_interval(fitter, t, nll_min, q, scan_kwargs)
+        finally:
+            if to_freeze:
+                fitter.defreeze_params(to_freeze)
+        return arr
+
+    group_names = []
+    group_impacts = []
+    for gname, gidxs in zip(fitter.indata.systgroups, fitter.indata.systgroupidxs):
+        members = [str(syst_names_str[int(i)]) for i in np.asarray(gidxs).astype(int)]
+        frozen_arr = scan_with_frozen(members)
+        arr = np.full((2, n_total), np.nan)
+        for t, c in target_cols.items():
+            arr[:, c] = _quad_subtract(totals[t], frozen_arr[:, c])
+        group_names.append(gname)
+        group_impacts.append(arr)
+
+    # stat: freeze every constrained nuisance; the remaining interval is the
+    # statistical (+ unconstrained-NOI) uncertainty, reported directly.
+    cw = fitter.indata.constraintweights.numpy()
+    constrained = [str(syst_names_str[i]) for i in np.where(cw > 0)[0]]
+    group_names.append(b"stat")
+    group_impacts.append(scan_with_frozen(constrained))
+
+    # Total: the unfrozen interval itself.
+    arr = np.full((2, n_total), np.nan)
+    for t, c in target_cols.items():
+        arr[:, c] = totals[t]
+    group_names.append(b"Total")
+    group_impacts.append(arr)
+
+    logger.info(f"grouped asym impacts: total {time.perf_counter() - t0:.1f}s")
+
+    return np.asarray(group_names), np.stack(group_impacts)
 
 
 def asym_impacts_parms(
@@ -102,6 +197,7 @@ def asym_impacts_parms(
     nll_min,
     selected_idxs,
     selected_names,
+    targets=None,
     q=1,
     contour_xtol=1e-4,
     contour_gtol=1e-4,
@@ -115,15 +211,18 @@ def asym_impacts_parms(
         nll_min: postfit reduced NLL.
         selected_idxs: indices into the syst axis (0..nsyst-1) of nuisances to scan.
         selected_names: names of those nuisances (bytes), used as impact-axis labels.
+        targets: parameter names (str, typically POIs + NOIs) for which the
+            freeze-group grouped impacts are computed. Empty/None skips the
+            grouped computation.
         q: contour level (q=1 -> 1 sigma, q=4 -> 2 sigma).
 
     Returns:
         parms: np.ndarray of bytes, the impact-axis labels.
         impacts: np.ndarray of shape (n_scanned, 2, n_total_params).
             Axis 1 is [down, up] matching axis_downUpVar.
-        group_names: np.ndarray of bytes for groups containing scanned nuisances
-            (plus a trailing "Total").
-        impacts_grouped: np.ndarray of shape (n_groups, 2, n_total_params).
+        group_names: np.ndarray of bytes, [systgroups..., stat, Total].
+        impacts_grouped: np.ndarray of shape (n_groups, 2, n_total_params),
+            NaN outside the target columns (see grouped_asym_impacts).
     """
     n_scanned = len(selected_idxs)
     n_total = len(fitter.parms)
@@ -166,39 +265,25 @@ def asym_impacts_parms(
             f"max {t_per.max():.2f}s per nuisance)"
         )
 
-    # Build grouped impacts with the correlation-aware combination,
-    # separately for down/up (see _group_impact). Nuisance j (syst index)
-    # sits at full-x index nparams + j.
-    selected_set = set(selected_idxs.tolist())
-    pos_in_scanned = {int(idx): k for k, idx in enumerate(selected_idxs)}
-    cov = fitter.cov.numpy()
-    nparams = fitter.param_model.nparams
-
-    group_names = []
-    group_impacts = []
-    for gname, gidxs in zip(fitter.indata.systgroups, fitter.indata.systgroupidxs):
-        gidxs = np.asarray(gidxs).astype(int)
-        in_group = [int(i) for i in gidxs if int(i) in selected_set]
-        if not in_group:
-            continue
-        in_scanned = [pos_in_scanned[i] for i in in_group]
-        rho_inv = _rho_inv_for(cov, [nparams + i for i in in_group])
-        group_names.append(gname)
-        group_impacts.append(_group_impact(impacts[in_scanned], rho_inv))
-
-    if n_scanned > 0:
-        rho_inv = _rho_inv_for(cov, [nparams + int(i) for i in selected_idxs])
-        group_names.append(b"Total")
-        group_impacts.append(_group_impact(impacts, rho_inv))
-
-    if group_impacts:
-        impacts_grouped = np.stack(group_impacts)
+    # Grouped impacts via the freeze-group convention (independent of the
+    # per-nuisance scan selection above).
+    if targets:
+        scan_kwargs = dict(
+            xtol=contour_xtol,
+            gtol=contour_gtol,
+            maxiter=contour_maxiter,
+            hess_mode=hess_mode,
+        )
+        group_names, impacts_grouped = grouped_asym_impacts(
+            fitter, nll_min, targets, q=q, scan_kwargs=scan_kwargs
+        )
     else:
+        group_names = np.asarray([], dtype=bytes)
         impacts_grouped = np.zeros((0, 2, n_total))
 
     return (
         np.asarray(selected_names),
         impacts,
-        np.asarray(group_names),
+        group_names,
         impacts_grouped,
     )

--- a/rabbit/impacts/asym_impacts.py
+++ b/rabbit/impacts/asym_impacts.py
@@ -4,8 +4,10 @@ Traditional asymmetric impacts.
 For each selected nuisance, find the asymmetric +/- 1 sigma points on the
 Delta(2NLL)=q likelihood contour via constrained minimization (contour_scan).
 The shifts of every fitter parameter at those points are the asymmetric
-impacts. Group impacts are obtained by quadrature envelope of the contained
-nuisances, separately for the down and up sides.
+impacts. Group impacts follow the traditional grouped-impact convention,
+generalized to the asymmetric case: per side, sqrt(delta^T rho_GG^-1 delta)
+over the group's scanned nuisances, with rho_GG the postfit correlation
+submatrix (see _group_impact).
 
 All constrained nuisances are scanned by default (nonlinear effects can
 produce asymmetric impacts even for structurally symmetric templates);
@@ -48,23 +50,50 @@ def asymmetric_nuisance_mask(indata, atol=0.0):
     return np.any(np.abs(halfdiff) > atol, axis=axes)
 
 
-def _envelope(values):
-    """Quadrature envelope of asymmetric impacts within a group.
+def _group_impact(values, rho_inv):
+    """Correlation-aware group combination of asymmetric impacts.
+
+    Asymmetric analogue of the traditional grouped-impact convention
+    (sqrt(v^T C_GG^-1 v) in traditional_impacts._compute_impact_group):
+    per side s, the group impact on each parameter is
+
+        sqrt( delta_s^T rho_GG^-1 delta_s )
+
+    where delta_s is the vector of per-nuisance impacts on that parameter at
+    the side-s contour points and rho_GG is the postfit correlation submatrix
+    of the group's nuisances. In the symmetric Gaussian limit
+    (delta_j = cov[i, j] / sqrt(cov[j, j])) this reproduces the traditional
+    grouped impact exactly; for uncorrelated nuisances it reduces to a
+    quadrature sum.
 
     Args:
         values: numpy array of shape (n_in_group, 2, n_total_params), where
             axis 1 is [down, up].
+        rho_inv: numpy array of shape (n_in_group, n_in_group), the inverse
+            postfit correlation matrix of the group's nuisances.
 
     Returns:
-        Array of shape (2, n_total_params) with the envelope's lower (negative)
+        Array of shape (2, n_total_params) with the group's lower (negative)
         and upper (positive) sides.
     """
-    zeros = np.zeros((values.shape[0], values.shape[-1]), dtype=values.dtype)
-    vmin = np.min(values, axis=1)
-    vmax = np.max(values, axis=1)
-    lower = -np.sqrt(np.sum(np.minimum(zeros, vmin) ** 2, axis=0))
-    upper = np.sqrt(np.sum(np.maximum(zeros, vmax) ** 2, axis=0))
+    down = values[:, 0, :]
+    up = values[:, 1, :]
+    # rho_inv is positive-definite so the quadratic form is >= 0; the clip
+    # only guards against floating-point round-off.
+    q_down = np.einsum("jt,jk,kt->t", down, rho_inv, down)
+    q_up = np.einsum("jt,jk,kt->t", up, rho_inv, up)
+    lower = -np.sqrt(np.clip(q_down, 0.0, None))
+    upper = np.sqrt(np.clip(q_up, 0.0, None))
     return np.stack([lower, upper])
+
+
+def _rho_inv_for(cov, x_idxs):
+    """Inverse postfit correlation submatrix for the given full-x indices."""
+    sub = cov[np.ix_(x_idxs, x_idxs)]
+    sigma = np.sqrt(np.diag(sub))
+    rho = sub / np.outer(sigma, sigma)
+    # pinv for robustness against near-degenerate (highly correlated) groups.
+    return np.linalg.pinv(rho)
 
 
 def asym_impacts_parms(
@@ -136,25 +165,30 @@ def asym_impacts_parms(
             f"max {t_per.max():.2f}s per nuisance)"
         )
 
-    # Build grouped impacts via quadrature envelope, separately for down/up.
-    syst_names = np.array(fitter.indata.systs).astype(bytes)
+    # Build grouped impacts with the correlation-aware combination,
+    # separately for down/up (see _group_impact). Nuisance j (syst index)
+    # sits at full-x index nparams + j.
     selected_set = set(selected_idxs.tolist())
     pos_in_scanned = {int(idx): k for k, idx in enumerate(selected_idxs)}
+    cov = fitter.cov.numpy()
+    nparams = fitter.param_model.nparams
 
     group_names = []
     group_impacts = []
     for gname, gidxs in zip(fitter.indata.systgroups, fitter.indata.systgroupidxs):
         gidxs = np.asarray(gidxs).astype(int)
-        in_scanned = [pos_in_scanned[i] for i in gidxs if int(i) in selected_set]
-        if not in_scanned:
+        in_group = [int(i) for i in gidxs if int(i) in selected_set]
+        if not in_group:
             continue
-        sub = impacts[in_scanned]
+        in_scanned = [pos_in_scanned[i] for i in in_group]
+        rho_inv = _rho_inv_for(cov, [nparams + i for i in in_group])
         group_names.append(gname)
-        group_impacts.append(_envelope(sub))
+        group_impacts.append(_group_impact(impacts[in_scanned], rho_inv))
 
     if n_scanned > 0:
+        rho_inv = _rho_inv_for(cov, [nparams + int(i) for i in selected_idxs])
         group_names.append(b"Total")
-        group_impacts.append(_envelope(impacts))
+        group_impacts.append(_group_impact(impacts, rho_inv))
 
     if group_impacts:
         impacts_grouped = np.stack(group_impacts)

--- a/rabbit/impacts/asym_impacts.py
+++ b/rabbit/impacts/asym_impacts.py
@@ -9,12 +9,13 @@ generalized to the asymmetric case: per side, sqrt(delta^T rho_GG^-1 delta)
 over the group's scanned nuisances, with rho_GG the postfit correlation
 submatrix (see _group_impact).
 
-All constrained nuisances are scanned by default (nonlinear effects can
-produce asymmetric impacts even for structurally symmetric templates);
-use include/exclude to restrict the selection. Unconstrained nuisances
-(constraintweight = 0) are skipped since they have no finite Delta(2NLL)
-contour. An optional structural-symmetry skip (logkhalfdiff identically
-zero) is available programmatically via skip_symmetric.
+All nuisances are scanned by default, including unconstrained ones — like
+the symmetric traditional impacts, the data still gives them a finite
+postfit uncertainty and hence a finite Delta(2NLL)=q contour (nonlinear
+effects can also produce asymmetric impacts even for structurally
+symmetric templates). Use include/exclude to restrict the selection. An
+optional structural-symmetry skip (logkhalfdiff identically zero) is
+available programmatically via skip_symmetric.
 """
 
 import time

--- a/rabbit/impacts/global_asym_impacts.py
+++ b/rabbit/impacts/global_asym_impacts.py
@@ -1,0 +1,209 @@
+"""
+Fully likelihood-based asymmetric global impacts.
+
+For each selected nuisance i, shift the auxiliary (global) observable theta0[i]
+by +/- 1 prefit sigma and re-run the full fit. The resulting POI shifts are the
+asymmetric global impacts. This is option (c) of the three definitions listed
+in global_impacts.py and complements the Gaussian variants there:
+
+  - global_impacts_parms / gaussian_global_impacts_parms: analytic, single-sided.
+  - global_asym_impacts_parms (this module): fully likelihood, two-sided, exact.
+
+In the Gaussian limit this reproduces gaussian_global_impacts_parms; deviations
+measure the non-Gaussianity of the joint profile around the postfit minimum.
+
+Differs from nonprofiled_impacts in two ways:
+  - nuisance i is *profiled* (not frozen), so it can equilibrate at the new
+    constraint center together with all correlated nuisances;
+  - beta (BBB) parameters are profiled too, regardless of --noPostfitProfileBB.
+"""
+
+import time
+
+import numpy as np
+import tensorflow as tf
+from wums import logging
+
+logger = logging.child_logger(__name__)
+
+
+def _envelope(values):
+    """Quadrature envelope of asymmetric impacts within a group, separately for
+    the down and up sides.
+
+    Args:
+        values: numpy array of shape (n_in_group, 2, n_total_params), where
+            axis 1 is [down, up].
+
+    Returns:
+        Array of shape (2, n_total_params).
+    """
+    zeros = np.zeros((values.shape[0], values.shape[-1]), dtype=values.dtype)
+    vmin = np.min(values, axis=1)
+    vmax = np.max(values, axis=1)
+    lower = -np.sqrt(np.sum(np.minimum(zeros, vmin) ** 2, axis=0))
+    upper = np.sqrt(np.sum(np.maximum(zeros, vmax) ** 2, axis=0))
+    return np.stack([lower, upper])
+
+
+def global_asym_impacts_parms(
+    fitter,
+    selected_idxs,
+    selected_names,
+    sigma=1.0,
+    signs=(-1, 1),
+    linear_warmstart=False,
+):
+    """Run a per-nuisance theta0-shift + re-fit and assemble the asymmetric
+    global impact tensor.
+
+    Args:
+        fitter: the Fitter instance (used for x, theta0 and minimize).
+        selected_idxs: indices into the syst axis (0..nsyst-1) of nuisances to
+            scan.
+        selected_names: names of those nuisances (bytes), used as impact-axis
+            labels.
+        sigma: shift magnitude in units of the prefit constraint width
+            (constraints are unit-sigma in rabbit, so 1.0 = 1 prefit sigma).
+        signs: sequence (down, up). Bin 0 of axis_downUpVar -> first sign.
+        linear_warmstart: experimental. If True, warm-start each refit at
+            x_nom + dxdtheta0[:, i] * shift, the Gaussian-approximation new
+            minimum for the shifted theta0. Should drastically reduce the
+            number of optimizer iterations on near-Gaussian nuisances.
+            Requires fitter.cov to exist (same prerequisite as
+            --gaussianGlobalImpacts).
+
+    Returns:
+        parms: np.ndarray of bytes, the impact-axis labels.
+        impacts: np.ndarray of shape (n_scanned, 2, n_total_params).
+            Axis 1 is [down, up] matching axis_downUpVar.
+        group_names: np.ndarray of bytes for groups containing scanned
+            nuisances (plus a trailing "Total").
+        impacts_grouped: np.ndarray of shape (n_groups, 2, n_total_params).
+    """
+    n_scanned = len(selected_idxs)
+    n_total = len(fitter.parms)
+    impacts = np.zeros((n_scanned, 2, n_total))
+
+    nparams = fitter.param_model.nparams
+
+    # Snapshot postfit nominal state to restore between iterations.
+    x_nom = tf.identity(fitter.x.value())
+    theta0_nom = tf.identity(fitter.theta0.value())
+    theta0_nom_np = theta0_nom.numpy()
+    x_nom_np = x_nom.numpy()
+
+    logger.info(
+        f"global_asym_impacts: shifting theta0 by +/- {sigma} sigma and "
+        f"re-fitting for {n_scanned} nuisances"
+        + (" (linear warm-start enabled)" if linear_warmstart else "")
+    )
+
+    # Optional Gaussian-approximation warm-start.
+    # dxdtheta0 has shape [npar, nsyst]; column i gives the linearised
+    # response of the postfit minimum to a unit shift of theta0[i]. Computing
+    # it once before the loop is the same cost as one --gaussianGlobalImpacts
+    # call.
+    dxdtheta0_np = None
+    if linear_warmstart:
+        if fitter.cov is None:
+            raise RuntimeError(
+                "global_asym_impacts: linear_warmstart requires fitter.cov "
+                "(incompatible with --noHessian)."
+            )
+        t_lws = time.perf_counter()
+        dxdtheta0_tf, _, _ = fitter._dxdvars()
+        dxdtheta0_np = dxdtheta0_tf.numpy()
+        logger.info(
+            f"global_asym_impacts: dxdtheta0 prepared in "
+            f"{time.perf_counter() - t_lws:.2f}s"
+        )
+
+    t_per = np.zeros(n_scanned, dtype=np.float64)
+    t_total0 = time.perf_counter()
+
+    for k, i in enumerate(selected_idxs):
+        i = int(i)
+        name = selected_names[k]
+        name_str = name.decode() if isinstance(name, bytes) else name
+        logger.info(f"  [{k + 1}/{n_scanned}] theta0-shift refit for {name_str}")
+
+        t0 = time.perf_counter()
+        for j, sign in enumerate(signs):
+            shift = float(sign) * float(sigma)
+
+            # Always shift the constraint center for nuisance i by `shift`.
+            theta0_shifted = theta0_nom_np.copy()
+            theta0_shifted[i] += shift
+
+            # Warm-start x. With linear_warmstart, use the Gaussian-approx new
+            # minimum x_nom + dxdtheta0[:, i] * shift -- on near-Gaussian
+            # nuisances this lands at the new minimum to within roundoff.
+            # Without it, just shift x[nparams+i] by `shift` so the nuisance
+            # itself starts at the new constraint center.
+            if linear_warmstart:
+                x_shifted = x_nom_np + dxdtheta0_np[:, i] * shift
+            else:
+                x_shifted = x_nom_np.copy()
+                x_shifted[nparams + i] += shift
+
+            fitter.theta0.assign(theta0_shifted)
+            fitter.x.assign(x_shifted)
+
+            try:
+                fitter.minimize()
+                if fitter.bbstat.enabled:
+                    fitter._profile_beta()
+                impacts[k, j] = (fitter.x.value() - x_nom).numpy()
+            except Exception as e:
+                logger.warning(
+                    f"    refit for {name_str} sign={sign:+d} failed: {e}; "
+                    "leaving impact at zero"
+                )
+
+        t_per[k] = time.perf_counter() - t0
+        logger.info(f"    took {t_per[k]:.2f}s")
+
+    # Restore the fit state so downstream postfit computations see the nominal.
+    fitter.theta0.assign(theta0_nom)
+    fitter.x.assign(x_nom)
+    if fitter.bbstat.enabled:
+        fitter._profile_beta()
+
+    if n_scanned > 0:
+        t_total = time.perf_counter() - t_total0
+        logger.info(
+            f"global_asym_impacts: total {t_total:.1f}s "
+            f"(mean {t_per.mean():.2f}s, min {t_per.min():.2f}s, "
+            f"max {t_per.max():.2f}s per nuisance)"
+        )
+
+    # Grouped impacts via quadrature envelope, separately for down/up.
+    selected_set = set(int(idx) for idx in selected_idxs)
+    pos_in_scanned = {int(idx): k for k, idx in enumerate(selected_idxs)}
+
+    group_names = []
+    group_impacts = []
+    for gname, gidxs in zip(fitter.indata.systgroups, fitter.indata.systgroupidxs):
+        gidxs = np.asarray(gidxs).astype(int)
+        in_scanned = [pos_in_scanned[i] for i in gidxs if int(i) in selected_set]
+        if not in_scanned:
+            continue
+        group_names.append(gname)
+        group_impacts.append(_envelope(impacts[in_scanned]))
+
+    if n_scanned > 0:
+        group_names.append(b"Total")
+        group_impacts.append(_envelope(impacts))
+
+    if group_impacts:
+        impacts_grouped = np.stack(group_impacts)
+    else:
+        impacts_grouped = np.zeros((0, 2, n_total))
+
+    return (
+        np.asarray(selected_names),
+        impacts,
+        np.asarray(group_names),
+        impacts_grouped,
+    )

--- a/rabbit/impacts/traditional_impacts.py
+++ b/rabbit/impacts/traditional_impacts.py
@@ -16,58 +16,76 @@ def _compute_impact_group(cov, v, idxs, nsignal_params=0):
     return tf.sqrt(v_invC_v)
 
 
-def _gather_poi_noi_vector(v, noiidxs, nsignal_params=0):
+def _gather_poi_noi_vector(v, noiidxs, nsignal_params=0, nmodel_params=None):
+    # nmodel_params = npoi + npou
+    if nmodel_params is None:
+        nmodel_params = nsignal_params
     v_poi = v[:nsignal_params]
     # protection for constained NOIs, set them to 0
-    mask = (noiidxs >= 0) & (noiidxs < tf.shape(v[nsignal_params:])[0])
+    mask = (noiidxs >= 0) & (noiidxs < tf.shape(v[nmodel_params:])[0])
     safe_idxs = tf.where(mask, noiidxs, 0)
     mask = tf.cast(mask, v.dtype)
     mask = tf.reshape(
         mask,
         tf.concat([tf.shape(mask), tf.ones(tf.rank(v) - 1, dtype=tf.int32)], axis=0),
     )
-    v_noi = tf.gather(v[nsignal_params:], safe_idxs) * mask
+    v_noi = tf.gather(v[nmodel_params:], safe_idxs) * mask
     v_gathered = tf.concat([v_poi, v_noi], axis=0)
     return v_gathered
 
 
 def impacts_parms(
-    cov, cov_stat, cov_stat_no_bbb, nsignal_params=0, noiidxs=[], systgroupidxs=[]
+    cov,
+    cov_stat,
+    cov_stat_no_bbb,
+    nsignal_params=0,
+    noiidxs=[],
+    systgroupidxs=[],
+    nmodel_params=None,
+    param_groupidxs=None,
 ):
     """
     Gaussian approximation
     """
+    if nmodel_params is None:
+        nmodel_params = nsignal_params
 
     # impact for poi at index i in covariance matrix from nuisance with index j is C_ij/sqrt(C_jj) = <deltax deltatheta>/sqrt(<deltatheta^2>)
-    v = _gather_poi_noi_vector(cov, noiidxs, nsignal_params)
-    impacts = v / tf.reshape(tf.sqrt(tf.linalg.diag_part(cov)), [1, -1])
+    v = _gather_poi_noi_vector(cov, noiidxs, nsignal_params, nmodel_params)
+    # Frozen / fixed parameters have zero variance (cov diag == 0); their impact
+    # is zero, not 0/0 = nan. Guard the denominator so those columns read 0.
+    sigma = tf.sqrt(tf.linalg.diag_part(cov))
+    safe_sigma = tf.where(sigma > 0, sigma, tf.ones_like(sigma))
+    impacts = v / tf.reshape(safe_sigma, [1, -1])
 
     if cov_stat_no_bbb is not None:
         # impact bin-by-bin stat
         impacts_data_stat = tf.sqrt(tf.linalg.diag_part(cov_stat_no_bbb))
         impacts_data_stat = _gather_poi_noi_vector(
-            impacts_data_stat, noiidxs, nsignal_params
+            impacts_data_stat, noiidxs, nsignal_params, nmodel_params
         )
         impacts_data_stat = tf.reshape(impacts_data_stat, (-1, 1))
 
         impacts_bbb_sq = tf.linalg.diag_part(cov_stat - cov_stat_no_bbb)
-        impacts_bbb_sq = _gather_poi_noi_vector(impacts_bbb_sq, noiidxs, nsignal_params)
+        impacts_bbb_sq = _gather_poi_noi_vector(
+            impacts_bbb_sq, noiidxs, nsignal_params, nmodel_params
+        )
         impacts_bbb = tf.sqrt(tf.nn.relu(impacts_bbb_sq))  # max(0,x)
         impacts_bbb = tf.reshape(impacts_bbb, (-1, 1))
         impacts_grouped = tf.concat([impacts_data_stat, impacts_bbb], axis=1)
     else:
         impacts_data_stat = tf.sqrt(tf.linalg.diag_part(cov_stat))
         impacts_data_stat = _gather_poi_noi_vector(
-            impacts_data_stat, noiidxs, nsignal_params
+            impacts_data_stat, noiidxs, nsignal_params, nmodel_params
         )
         impacts_data_stat = tf.reshape(impacts_data_stat, (-1, 1))
         impacts_grouped = impacts_data_stat
 
     if len(systgroupidxs):
+        # systgroupidxs are syst-relative -> shift into full-x by nmodel_params
+        # and gather from the full covariance (nsignal_params=0 path).
         impacts_grouped_syst = tf.map_fn(
-            lambda idxs: _compute_impact_group(
-                cov, v[:, nsignal_params:], idxs, nsignal_params
-            ),
+            lambda idxs: _compute_impact_group(cov, v, nmodel_params + idxs, 0),
             tf.ragged.constant(systgroupidxs, dtype=tf.int32),
             fn_output_signature=tf.TensorSpec(
                 shape=(impacts.shape[0],), dtype=tf.float64
@@ -75,5 +93,18 @@ def impacts_parms(
         )
         impacts_grouped_syst = tf.transpose(impacts_grouped_syst)
         impacts_grouped = tf.concat([impacts_grouped_syst, impacts_grouped], axis=1)
+
+    if param_groupidxs:
+        # ParamModel parameter groups, already in full-x space (floating-filtered).
+        # Appended at the END so the grouped-impact axis is
+        # [syst groups, stat, (binByBinStat), param groups].
+        param_cols = [
+            tf.reshape(
+                _compute_impact_group(cov, v, tf.constant(g, dtype=tf.int32), 0),
+                (-1, 1),
+            )
+            for g in param_groupidxs
+        ]
+        impacts_grouped = tf.concat([impacts_grouped, *param_cols], axis=1)
 
     return impacts, impacts_grouped

--- a/rabbit/impacts/traditional_impacts.py
+++ b/rabbit/impacts/traditional_impacts.py
@@ -45,7 +45,14 @@ def impacts_parms(
     param_groupidxs=None,
 ):
     """
-    Gaussian approximation
+    Gaussian approximation.
+
+    Impacts are computed FOR the POIs and NOIs only (the rows of the
+    returned tensors). nmodel_params = npoi + npou is needed to locate the
+    NOI entries in the full parameter vector when the ParamModel has POU
+    (model nuisance) parameters; the POUs themselves do not get impact
+    rows. POUs enter only as impact *sources*: optionally grouped via
+    param_groupidxs (columns appended after the syst/stat groups).
     """
     if nmodel_params is None:
         nmodel_params = nsignal_params

--- a/rabbit/io_tools.py
+++ b/rabbit/io_tools.py
@@ -47,7 +47,9 @@ def read_impacts_poi(
 ):
     # read impacts of a single POI
 
-    if asym and impact_type == "traditional":
+    if asym and impact_type == "traditional" and "impacts_asym" not in fitresult.keys():
+        # Fallback: read asymmetric traditional impacts from a generic
+        # contour scan output if --asymImpacts wasn't run.
         h_impacts = fitresult["contour_scans"].get()[{"confidence_level": "1.0"}]
     else:
         impact_name = "impacts"

--- a/rabbit/workspace.py
+++ b/rabbit/workspace.py
@@ -13,13 +13,19 @@ axis_downUpVar = hist.axis.Regular(
 )
 
 
-def getGroupedImpactsAxes(indata, bin_by_bin_stat=False, per_process=False):
+def getGroupedImpactsAxes(
+    indata, bin_by_bin_stat=False, per_process=False, extra_groups=None
+):
     impact_names = list(indata.systgroups.astype(str))
     impact_names.append("stat")
     if bin_by_bin_stat:
         impact_names.append("binByBinStat")
         if per_process:
             impact_names.extend([f"binByBinStat{p}" for p in indata.procs.astype(str)])
+    # ParamModel parameter groups are appended at the end, matching the column
+    # order produced by traditional_impacts.impacts_parms.
+    if extra_groups:
+        impact_names.extend(extra_groups)
     return hist.axis.StrCategory(impact_names, name="impacts")
 
 
@@ -59,8 +65,16 @@ class Workspace:
         parms = list(fitter.parms.astype(str))
         self.impact_axis = hist.axis.StrCategory(parms, name="impacts")
         self.global_impact_axis = hist.axis.StrCategory(systs, name="impacts")
+        # ParamModel impact groups (e.g. SCETlib NP gamma_nu / F_eff) are only
+        # computed by the traditional impacts, so extend that axis only.
+        param_impact_group_names = [
+            name for name, _ in fitter._resolved_param_impact_groups()
+        ]
         self.grouped_impact_axis = getGroupedImpactsAxes(
-            fitter.indata, bin_by_bin_stat=fitter.bbstat.enabled, per_process=False
+            fitter.indata,
+            bin_by_bin_stat=fitter.bbstat.enabled,
+            per_process=False,
+            extra_groups=param_impact_group_names,
         )
         self.grouped_global_impact_axis = getGroupedImpactsAxes(
             fitter.indata,

--- a/tests/test_global_asym_impacts.py
+++ b/tests/test_global_asym_impacts.py
@@ -1,0 +1,338 @@
+"""End-to-end correctness tests for --globalAsymImpacts.
+
+Builds a tensor with both symmetric and asymmetric nuisances via
+tests/make_tensor.py, then runs three fits and checks:
+
+  T1 Gaussian-limit closure: at sigma=0.01, globalAsym up/sigma matches
+     gaussianGlobalImpacts to ~1e-3 relative.
+  T2 Symmetry at small sigma: up = -down to ~1e-3 relative.
+  T3 Asymmetry detection: at sigma=1.0, the structurally asymmetric nuisance
+     slope_2_signal_ch1 has |up+down| above a threshold; structurally
+     symmetric nuisances stay close to zero.
+  T4 State restoration: postfit `parms` histogram values are bit-identical
+     between a baseline fit and the --globalAsymImpacts fit (same seed).
+  T5 Output schema: global_impacts_asym and *_grouped exist with axes
+     (impacts, downUpVar, parms).
+  T6 Unconstrained nuisances skipped: slope_background / slope_signal not
+     in the impacts axis.
+
+Run: source /opt/env.sh && source setup.sh
+     python tests/test_global_asym_impacts.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from rabbit import io_tools
+
+OUTDIR = Path("/tmp/test_global_asym_impacts")
+TENSOR = OUTDIR / "test_tensor.hdf5"
+
+# Names taken from tests/make_tensor.py
+#
+# slope_2_signal_ch1 is added with symmetrize=None -> rabbit stores logkhalfdiff
+# != 0, so this is the only nuisance for which down vs up should disagree at
+# sigma=1 beyond minimizer noise. (slope_signal_ch0 also has kfactor=1.2 but
+# is an NOI, treated separately by the model.)
+ASYMMETRIC_NUIS = "slope_2_signal_ch1"
+# The SymAvg/SymDiff partners produced by the symmetrize transforms have
+# logkhalfdiff identically zero: structurally symmetric internal nuisances.
+SYMMETRIC_NUIS = [
+    "slope_lin_signal_ch0SymAvg",
+    "slope_lin_signal_ch0SymDiff",
+    "slope_quad_signal_ch0SymAvg",
+    "slope_quad_signal_ch0SymDiff",
+    "slope_signal_ch1",  # symmetrize="conservative" -> single sym nuisance
+    "norm",  # pure norm systematics
+    "bkg_norm",
+    "bkg_2_norm",
+]
+UNCONSTRAINED_NUIS = ["slope_background", "slope_signal"]
+
+
+def run(cmd: list[str]) -> None:
+    print("$", " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def make_tensor() -> None:
+    OUTDIR.mkdir(parents=True, exist_ok=True)
+    run([sys.executable, "tests/make_tensor.py", "-o", str(OUTDIR) + "/"])
+    assert TENSOR.exists(), TENSOR
+
+
+def fit(label: str, *extra: str) -> Path:
+    out = OUTDIR / label
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir()
+    run(
+        [
+            "rabbit_fit.py",
+            str(TENSOR),
+            "-o",
+            str(out),
+            "--seed",
+            "42",
+            *extra,
+        ]
+    )
+    return out / "fitresults.hdf5"
+
+
+def load_results(path: Path) -> dict:
+    return io_tools.get_fitresult(str(path))
+
+
+def get_impact_array(res: dict, name: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return (values, parms_axis, impacts_axis) for an impacts hist."""
+    h = res[name].get()
+    impacts_axis = np.array(h.axes["impacts"])
+    parms_axis = np.array(h.axes["parms"])
+    return h.values(), parms_axis, impacts_axis
+
+
+def get_nuis_idx(impacts_axis: np.ndarray, name: str) -> int:
+    matches = np.where(impacts_axis.astype(str) == name)[0]
+    if len(matches) == 0:
+        raise KeyError(
+            f"{name!r} not in impacts axis: {list(impacts_axis.astype(str))}"
+        )
+    return int(matches[0])
+
+
+def get_poi_idx(parms_axis: np.ndarray, name: str) -> int:
+    return int(np.where(parms_axis.astype(str) == name)[0][0])
+
+
+# ---------------------------------------------------------------------------
+
+
+def t1_gaussian_closure(res_small: dict, res_gauss: dict) -> None:
+    """At sigma=0.01, globalAsym up/sigma must match gaussianGlobal."""
+    print("\n[T1] Gaussian-limit closure (sigma=0.01)")
+
+    sigma = 0.01
+    asym, asym_parms, asym_impacts = get_impact_array(res_small, "global_impacts_asym")
+    # asym shape: (impacts, downUpVar, parms)
+    # gauss shape: (parms, impacts)
+    gauss_h = res_gauss["gaussian_global_impacts"].get()
+    g_vals = gauss_h.values()
+    g_parms = np.array(gauss_h.axes["parms"]).astype(str)
+    g_impacts = np.array(gauss_h.axes["impacts"]).astype(str)
+
+    poi = "sig"  # the only POI in make_tensor.py default config
+    poi_idx_asym = get_poi_idx(asym_parms, poi)
+    poi_idx_gauss = int(np.where(g_parms == poi)[0][0])
+
+    common = [n for n in asym_impacts.astype(str) if n in g_impacts]
+    print(f"  comparing {len(common)} nuisances on POI {poi!r}")
+
+    max_rel = 0.0
+    worst = None
+    for name in common:
+        i_asym = get_nuis_idx(asym_impacts, name)
+        i_gauss = int(np.where(g_impacts == name)[0][0])
+        up = asym[i_asym, 1, poi_idx_asym] / sigma
+        ref = g_vals[poi_idx_gauss, i_gauss]
+        # gaussian impact is unsigned; compare magnitudes
+        denom = max(abs(ref), 1e-12)
+        rel = abs(abs(up) - abs(ref)) / denom
+        if rel > max_rel:
+            max_rel, worst = rel, (name, up, ref)
+
+    print(f"  max relative diff: {max_rel:.3e}  (worst: {worst})")
+    assert max_rel < 5e-2, (
+        f"T1 FAIL: globalAsym at sigma=0.01 deviates from gaussianGlobal by "
+        f"{max_rel:.3e} on {worst!r}; expected closure <5%"
+    )
+    print("  T1 PASS")
+
+
+def t2_small_sigma_symmetry(res_small: dict) -> None:
+    """At sigma=0.01, down ~ -up for every scanned nuisance."""
+    print("\n[T2] Small-sigma symmetry (sigma=0.01: up = -down)")
+
+    asym, asym_parms, asym_impacts = get_impact_array(res_small, "global_impacts_asym")
+    poi_idx = get_poi_idx(asym_parms, "sig")
+
+    max_rel = 0.0
+    worst = None
+    for k, name in enumerate(asym_impacts.astype(str)):
+        down = asym[k, 0, poi_idx]
+        up = asym[k, 1, poi_idx]
+        denom = max(abs(up), abs(down), 1e-12)
+        rel = abs(up + down) / denom
+        if rel > max_rel:
+            max_rel, worst = rel, (name, up, down)
+
+    print(f"  max |up+down|/max(|up|,|down|): {max_rel:.3e}  (worst: {worst})")
+    assert max_rel < 5e-2, f"T2 FAIL: not symmetric at small sigma; worst={worst}"
+    print("  T2 PASS")
+
+
+def t3_asymmetry_at_full_sigma(res_full: dict, res_small: dict) -> None:
+    """At sigma=1.0 the method must produce non-trivial asymmetry, and the
+    asymmetry must scale with sigma.
+
+    Note: even structurally symmetric nuisances (logkhalfdiff=0) can show
+    asymmetric impacts at sigma=1.0 with systematic_type="log_normal", because
+    the kernel exp(+theta * logkavg) is asymmetric in theta away from the
+    quadratic basin. This is correct behaviour, not a bug. We therefore assert:
+      a) the structurally asymmetric nuisance shows clearly non-zero
+         asymmetry at sigma=1.0;
+      b) every nuisance that was symmetric at sigma=0.01 (validated by T2)
+         shows MORE asymmetry at sigma=1.0 than at sigma=0.01 -- i.e. the
+         asymmetry is a real sigma-dependent effect, not noise.
+    """
+    print("\n[T3] Asymmetry detection at sigma=1.0")
+
+    asym_full, asym_parms, asym_impacts = get_impact_array(
+        res_full, "global_impacts_asym"
+    )
+    asym_small, _, asym_impacts_small = get_impact_array(
+        res_small, "global_impacts_asym"
+    )
+    poi_idx = get_poi_idx(asym_parms, "sig")
+
+    def asymmetry(arr: np.ndarray, axis: np.ndarray, name: str) -> float:
+        k = get_nuis_idx(axis, name)
+        d, u = arr[k, 0, poi_idx], arr[k, 1, poi_idx]
+        return abs(u + d) / max(abs(u), abs(d), 1e-12)
+
+    # (a) structurally asymmetric nuisance must show measurable asymmetry.
+    impacts_str = asym_impacts.astype(str)
+    if ASYMMETRIC_NUIS not in impacts_str:
+        print(
+            f"  skip (a): {ASYMMETRIC_NUIS} not in impacts axis; "
+            f"list = {list(impacts_str)}"
+        )
+    else:
+        a = asymmetry(asym_full, asym_impacts, ASYMMETRIC_NUIS)
+        print(f"  asymmetry({ASYMMETRIC_NUIS}) at sigma=1.0 = {a:.3e}")
+        assert a > 1e-2, (
+            f"T3 FAIL (a): {ASYMMETRIC_NUIS} should be measurably asymmetric "
+            f"at sigma=1.0, got {a:.3e}"
+        )
+
+    # (b) every nuisance: asymmetry grows with sigma (within minimizer noise).
+    growth_floor = 1e-3
+    for name in asym_impacts.astype(str):
+        if name not in asym_impacts_small.astype(str):
+            continue
+        a_small = asymmetry(asym_small, asym_impacts_small, name)
+        a_full = asymmetry(asym_full, asym_impacts, name)
+        print(
+            f"  asymmetry({name}): sigma=0.01 -> {a_small:.3e}, "
+            f"sigma=1.0 -> {a_full:.3e}"
+        )
+        # Allow noise floor: even if the asymmetry is tiny, it should not
+        # *shrink* with sigma if sigma=0.01 was already at convergence noise.
+        assert a_full + growth_floor >= a_small, (
+            f"T3 FAIL (b): {name} asymmetry shrinks with sigma "
+            f"({a_small:.3e} -> {a_full:.3e})"
+        )
+    print("  T3 PASS")
+
+
+def t4_state_restoration(res_baseline: dict, res_full: dict) -> None:
+    """After the asym scan, postfit `parms` must match a vanilla fit's parms."""
+    print("\n[T4] State restoration (parms unchanged vs baseline)")
+
+    p0 = res_baseline["parms"].get().values()
+    p1 = res_full["parms"].get().values()
+    diff = np.max(np.abs(p0 - p1))
+    print(f"  max |parms_baseline - parms_after_asym| = {diff:.3e}")
+    # Same seed, same fit -> should be bit-identical, but allow a tiny float
+    # margin in case of any nondeterminism in the env.
+    assert diff < 1e-9, "T4 FAIL: postfit parms changed after the asym loop"
+    print("  T4 PASS")
+
+
+def t5_output_schema(res_full: dict) -> None:
+    print("\n[T5] Output schema")
+    assert "global_impacts_asym" in res_full, list(res_full.keys())
+    assert "global_impacts_asym_grouped" in res_full, list(res_full.keys())
+
+    h = res_full["global_impacts_asym"].get()
+    names = [a.name for a in h.axes]
+    print(f"  axes = {names}")
+    assert names == ["impacts", "downUpVar", "parms"], names
+
+    g = res_full["global_impacts_asym_grouped"].get()
+    gnames = [a.name for a in g.axes]
+    print(f"  grouped axes = {gnames}")
+    assert gnames == ["impacts", "downUpVar", "parms"], gnames
+
+    groups = list(np.array(g.axes["impacts"]).astype(str))
+    print(f"  groups = {groups}")
+    assert groups[-1] == "Total", groups
+    print("  T5 PASS")
+
+
+def t6_unconstrained_skipped(res_full: dict) -> None:
+    print("\n[T6] Unconstrained nuisances skipped")
+    _, _, impacts_axis = get_impact_array(res_full, "global_impacts_asym")
+    impacts_str = list(impacts_axis.astype(str))
+    print(f"  scanned nuisances = {impacts_str}")
+    for n in UNCONSTRAINED_NUIS:
+        assert n not in impacts_str, f"T6 FAIL: unconstrained {n!r} should be skipped"
+    print("  T6 PASS")
+
+
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    os.chdir(os.environ.get("RABBIT_BASE", "."))
+    make_tensor()
+
+    common = [
+        "--doImpacts",
+        "--gaussianGlobalImpacts",
+    ]
+
+    # baseline: just the fit, no asym scan -> reference parms
+    base_h5 = fit("baseline", *common)
+
+    # small-sigma asym for Gaussian closure & symmetry
+    small_h5 = fit(
+        "small_sigma",
+        *common,
+        "--globalAsymImpacts",
+        "--globalAsymImpactsSigma",
+        "0.01",
+    )
+
+    # full-sigma asym for asymmetry detection
+    full_h5 = fit(
+        "full_sigma",
+        *common,
+        "--globalAsymImpacts",
+        "--globalAsymImpactsSigma",
+        "1.0",
+    )
+
+    res_base = load_results(base_h5)
+    res_small = load_results(small_h5)
+    res_full = load_results(full_h5)
+
+    t5_output_schema(res_full)
+    t6_unconstrained_skipped(res_full)
+    t1_gaussian_closure(res_small, res_small)  # gaussianGlobal is in same file
+    t2_small_sigma_symmetry(res_small)
+    t3_asymmetry_at_full_sigma(res_full, res_small)
+    t4_state_restoration(res_base, res_full)
+
+    print("\nAll tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- traditional and global asymmetric impacts, with test coverage
- NOI gathering now uses `nmodel_params = npoi + npou`, so impacts are correct  when the ParamModel has POU (model-nuisance) parameters. POUs never get  impact rows; they act only as impact sources.