### PR TITLE
Make external likelihood terms proper Gaussians in the reported NLL

### DIFF
--- a/rabbit/external_likelihood.py
+++ b/rabbit/external_likelihood.py
@@ -1,11 +1,49 @@
 """Helpers for external likelihood terms (linear + quadratic parameter priors).
 
-An "external likelihood term" is an additive contribution to the NLL of
-the form
+An "external likelihood term" is an additive contribution to the NLL. For a
+Gaussian prior ``N(mu, C)`` on a subset of the fit parameters it is
 
-    -log L_ext = g^T x_sub + 0.5 * x_sub^T H x_sub
+    -log L_ext = 0.5 (x_sub - mu)^T H (x_sub - mu)  +  lognorm      (H = C^-1)
 
-where ``x_sub`` is the subset of the fit parameters the term constrains.
+which this module stores in the expanded form
+
+    -log L_ext = g^T x_sub + 0.5 x_sub^T H x_sub  +  const  +  lognorm
+
+with ``g = -H mu``. The two additive scalars are what make that expansion a
+proper Gaussian and are the reason they exist as separate stored quantities:
+
+``const`` = ``0.5 mu^T H mu`` = ``0.5 g^T H^-1 g``
+    Part of the *quadratic*, not a normalization: it is what makes the term
+    vanish at ``x_sub = mu``. Without it the term reads ``-0.5 mu^T H mu`` at
+    the prior mean, so any NLL containing an external term is offset by a
+    card-dependent amount and cannot be compared against a card without one.
+    Included in both the reduced and the full NLL, mirroring
+    ``Fitter._compute_lc``, which writes its own constraint term in centered
+    form ``cw * 0.5 * (x - x0)^2`` and therefore never loses this piece.
+
+``lognorm`` = ``0.5 (k log(2 pi) - log det H)``
+    The Gaussian normalization, i.e. ``0.5 log det(2 pi C)``. Depends only on
+    the prior width, never on ``x``. Included in the *full* NLL only, again
+    mirroring ``_compute_lc``, whose ``full_nll`` branch adds
+    ``0.9189 + log(sigma)`` per constrained parameter -- exactly this formula
+    in one dimension. Only defined for positive-definite ``H``; a term whose
+    ``H`` is not positive definite is not a probability density and gets
+    ``lognorm = 0`` with a warning.
+
+Neither scalar depends on ``x``, so neither can change a fit result: the
+minimum, gradient, Hessian, covariance, EDM and any NLL *difference* taken
+within a single fit are all unaffected. They change reported absolute NLL
+values (``nllvalreduced``, ``nllvalfull``, and the saturated chi2 built from
+``2 * nllvalreduced``), which is precisely where the omission was visible.
+
+Both scalars are derived automatically when the Hessian is dense. For a
+sparse Hessian the ``0.5 g^T H^-1 g`` solve and the ``log det`` are not
+cheap, so they must be supplied at write time instead -- see
+``TensorWriter.add_external_likelihood_term``, whose ``mean=`` argument
+computes ``const`` with a single matvec (``0.5 mu^T H mu`` needs no solve
+when ``mu`` is known) and is the recommended way to declare a Gaussian
+prior. Terms stored without them keep the historical uncorrected behaviour.
+
 Both the linear (``grad``) and quadratic (``hess_dense`` / ``hess_sparse``)
 parts are optional; the sparse Hessian is stored as a
 ``tf.sparse.SparseTensor`` whose indices are in canonical row-major order.
@@ -18,17 +56,105 @@ This module centralizes three things that were previously inlined in
   per-term dicts from an HDF5 group (used by FitInputData)
 * :func:`build_tf_external_terms` — turn that list into tf-side per-term
   dicts (resolved parameter indices, tf.constant grads, CSRSparseMatrix
-  Hessians). Used by the Fitter when it takes ownership of the input
-  data.
+  Hessians, and the two scalars above). Used by the Fitter when it takes
+  ownership of the input data.
 * :func:`compute_external_nll` — evaluate the scalar NLL contribution
   of a list of tf-side terms at the current ``x``.
 """
+
+import logging
 
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops.linalg.sparse import sparse_csr_matrix_ops as tf_sparse_csr
 
 from rabbit.h5pyutils_read import makesparsetensor, maketensor
+
+logger = logging.getLogger(__name__)
+
+
+def gaussian_scalars(grad, hess, name="<unnamed>"):
+    """Derive ``(const, lognorm)`` for a dense Gaussian external term.
+
+    Parameters
+    ----------
+    grad : ndarray or None
+        The linear part ``g``. ``None`` (or all-zero) means the quadratic is
+        already centered at the origin and ``const`` is 0.
+    hess : ndarray or None
+        The dense quadratic part ``H``. ``None`` means there is no quadratic
+        and hence neither scalar is defined.
+    name : str
+        Term name, used in warnings.
+
+    Returns
+    -------
+    (float, float)
+        ``const = 0.5 g^T H^-1 g`` and ``lognorm = 0.5 (k log 2pi - log det H)``.
+
+    Notes
+    -----
+    ``const`` is computed as ``0.5 g^T H^-1 g`` rather than by forming
+    ``mu = -H^-1 g`` first; the two are algebraically identical and this
+    avoids a second solve.
+
+    Degenerate cases are handled explicitly rather than raising, because the
+    ``g^T x + 0.5 x^T H x`` form is general enough to express things that are
+    not priors at all:
+
+    * ``H`` absent or zero -- a pure linear tilt. It has no minimum, so there
+      is no constant that centers it and none is added.
+    * ``g`` absent or zero -- already centered; ``const`` is 0 exactly.
+    * ``H`` singular -- a Gaussian on a subspace, flat elsewhere. The
+      pseudo-inverse gives the correct constant for the constrained subspace.
+      If ``g`` additionally has a component outside ``range(H)`` the term is
+      unbounded below and *no* constant centers it; that is warned about.
+    * ``H`` not positive definite -- a saddle rather than a density. The
+      centering constant is still well defined, but the normalization is not,
+      so ``lognorm`` is 0 with a warning.
+    """
+    if hess is None:
+        return 0.0, 0.0
+
+    H = np.asarray(hess, dtype=np.float64)
+    k = H.shape[0]
+    g = None if grad is None else np.asarray(grad, dtype=np.float64).ravel()
+
+    # --- const -------------------------------------------------------------
+    const = 0.0
+    if g is not None and np.any(g != 0.0):
+        # Symmetrize defensively: the loss uses 0.5 x^T H x, which only ever
+        # sees the symmetric part, so the constant must be built from the same.
+        Hs = 0.5 * (H + H.T)
+        eigvals = np.linalg.eigvalsh(Hs)
+        tol = max(k, 1) * np.finfo(np.float64).eps * max(abs(eigvals).max(), 1.0)
+        if abs(eigvals).min() > tol:
+            y = np.linalg.solve(Hs, g)
+        else:
+            y = np.linalg.pinv(Hs, rcond=tol) @ g
+            residual = Hs @ y - g
+            if np.linalg.norm(residual) > 1e-8 * max(np.linalg.norm(g), 1.0):
+                logger.warning(
+                    f"External likelihood term '{name}': the Hessian is singular and "
+                    "the gradient has a component outside its range, so the term is "
+                    "unbounded below and cannot be centered. Using the pseudo-inverse "
+                    "for the in-range part; absolute NLL values remain offset."
+                )
+        const = float(0.5 * g @ y)
+
+    # --- lognorm -----------------------------------------------------------
+    sign, logdet = np.linalg.slogdet(0.5 * (H + H.T))
+    if sign <= 0:
+        logger.warning(
+            f"External likelihood term '{name}': the Hessian is not positive "
+            "definite, so the term is not a normalizable Gaussian. Skipping its "
+            "log-normalization; the full NLL remains offset for this term."
+        )
+        lognorm = 0.0
+    else:
+        lognorm = float(0.5 * (k * np.log(2.0 * np.pi) - logdet))
+
+    return const, lognorm
 
 
 def read_external_terms_from_h5(ext_group):
@@ -42,6 +168,13 @@ def read_external_terms_from_h5(ext_group):
     * ``hess_dense``: 2D float ndarray or ``None``
     * ``hess_sparse``: :class:`tf.sparse.SparseTensor` or ``None`` (uses
       the same on-disk layout as ``hlogk_sparse`` / ``hnorm_sparse``)
+    * ``const``, ``lognorm``: float or ``None`` -- the Gaussian scalars
+      described in the module docstring. Optional on disk: absent means
+      "not supplied", which for a dense Hessian is filled in by
+      :func:`build_tf_external_terms` and for a sparse one leaves the term
+      uncorrected (historical behaviour). Note that ``None`` and a stored
+      ``0.0`` are deliberately distinguished, so a writer that has
+      determined a scalar really is zero can say so.
 
     Parameters
     ----------
@@ -83,6 +216,10 @@ def read_external_terms_from_h5(ext_group):
                 "grad_values": grad_values,
                 "hess_dense": hess_dense,
                 "hess_sparse": hess_sparse,
+                "const": (float(tg["const"][()]) if "const" in tg.keys() else None),
+                "lognorm": (
+                    float(tg["lognorm"][()]) if "lognorm" in tg.keys() else None
+                ),
             }
         )
     return terms
@@ -110,11 +247,21 @@ def build_tf_external_terms(terms, parms, dtype):
     dtype : tf.DType
         Fitter dtype for gradient / Hessian tensors.
 
+    * The Gaussian scalars ``const`` / ``lognorm`` (see the module
+      docstring) are filled in here when the term did not carry them and
+      the Hessian is dense. A sparse Hessian that arrives without them is
+      left uncorrected, with a warning: deriving ``const`` would need a
+      sparse solve and ``lognorm`` a sparse log-determinant, neither of
+      which belongs in a load path. Supply them at write time instead --
+      ``TensorWriter.add_external_likelihood_term(hess=..., mean=...)``
+      gets ``const`` from a single matvec.
+
     Returns
     -------
     list[dict]
         One entry per term with keys ``name``, ``indices``, ``grad``,
-        ``hess_dense``, ``hess_csr``. Empty if ``terms`` is empty.
+        ``hess_dense``, ``hess_csr``, ``const``, ``lognorm``. Empty if
+        ``terms`` is empty.
     """
     parms_str = np.asarray(parms).astype(str)
     parms_idx = {name: i for i, name in enumerate(parms_str)}
@@ -162,6 +309,31 @@ def build_tf_external_terms(terms, parms, dtype):
             # step.
             tf_hess_csr = tf_sparse_csr.CSRSparseMatrix(term["hess_sparse"])
 
+        const = term.get("const")
+        lognorm = term.get("lognorm")
+        if const is None or lognorm is None:
+            if term["hess_dense"] is not None:
+                d_const, d_lognorm = gaussian_scalars(
+                    term["grad_values"], term["hess_dense"], term["name"]
+                )
+                const = d_const if const is None else const
+                lognorm = d_lognorm if lognorm is None else lognorm
+            elif term["hess_sparse"] is not None:
+                logger.warning(
+                    f"External likelihood term '{term['name']}' has a sparse Hessian "
+                    "and no stored const/lognorm, so it cannot be centered or "
+                    "normalized here (that would need a sparse solve and "
+                    "log-determinant). Absolute NLL values will be offset for this "
+                    "term. Pass mean= to TensorWriter.add_external_likelihood_term "
+                    "to have them computed at write time."
+                )
+                const = 0.0 if const is None else const
+                lognorm = 0.0 if lognorm is None else lognorm
+            else:
+                # grad-only: a linear tilt with no minimum, nothing to center.
+                const = 0.0 if const is None else const
+                lognorm = 0.0 if lognorm is None else lognorm
+
         out.append(
             {
                 "name": term["name"],
@@ -169,16 +341,22 @@ def build_tf_external_terms(terms, parms, dtype):
                 "grad": tf_grad,
                 "hess_dense": tf_hess_dense,
                 "hess_csr": tf_hess_csr,
+                "const": float(const),
+                "lognorm": float(lognorm),
             }
         )
     return out
 
 
-def compute_external_nll(terms, x, dtype):
+def compute_external_nll(terms, x, dtype, full_nll=False):
     """Evaluate the scalar NLL contribution of a list of external terms.
 
-    For each term, adds ``g^T x_sub + 0.5 * x_sub^T H x_sub`` to the
-    running total. Sparse Hessian terms use ``sm.matmul`` for the
+    For each term, adds ``g^T x_sub + 0.5 * x_sub^T H x_sub + const`` to the
+    running total, plus ``lognorm`` when ``full_nll`` is set. The two scalars
+    are what turn the expanded quadratic back into a proper Gaussian; see the
+    module docstring. They are pre-computed (per term, at build time), so
+    adding them here costs one scalar add and cannot perturb the closed-form
+    gradient / HVP paths below. Sparse Hessian terms use ``sm.matmul`` for the
     ``H @ x_sub`` product, which dispatches to a multi-threaded CSR
     kernel and is much faster per call than the previous element-wise
     gather-based form. The autodiff gradient and HVP of
@@ -196,6 +374,10 @@ def compute_external_nll(terms, x, dtype):
         Current full parameter vector.
     dtype : tf.DType
         Dtype for the accumulator.
+    full_nll : bool
+        If set, also add each term's Gaussian log-normalization. Matches
+        ``Fitter._compute_lc``, which adds ``0.9189 + log(sigma)`` per
+        constrained parameter under the same flag.
 
     Returns
     -------
@@ -204,7 +386,11 @@ def compute_external_nll(terms, x, dtype):
     """
     if not terms:
         return None
-    total = tf.zeros([], dtype=dtype)
+    offset = sum(
+        t.get("const", 0.0) + (t.get("lognorm", 0.0) if full_nll else 0.0)
+        for t in terms
+    )
+    total = tf.constant(offset, dtype=dtype)
     for term in terms:
         x_sub = tf.gather(x, term["indices"])
         if term["grad"] is not None:

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -2100,10 +2100,20 @@ class Fitter:
 
         return ln, lc, lbeta, lpenalty, beta
 
-    def _compute_external_nll(self):
-        """Sum of external likelihood term contributions: sum_i (g_i^T x_sub + 0.5 x_sub^T H_i x_sub)."""
+    def _compute_external_nll(self, full_nll=False):
+        """Sum of external likelihood term contributions.
+
+        Each term contributes ``g_i^T x_sub + 0.5 x_sub^T H_i x_sub + const_i``,
+        plus its Gaussian log-normalization when ``full_nll`` is set. The two
+        scalars mirror the treatment of the native constraint term in
+        :meth:`_compute_lc`: that one is written in centered form, so its
+        "value at the prior mean is zero" property is automatic and only the
+        log-normalization is gated on ``full_nll``. External terms are stored
+        expanded, so the centering constant has to be added back explicitly.
+        See :mod:`rabbit.external_likelihood`.
+        """
         return external_likelihood.compute_external_nll(
-            self.external_terms, self.x, self.indata.dtype
+            self.external_terms, self.x, self.indata.dtype, full_nll=full_nll
         )
 
     def _compute_nll(self, profile=True, full_nll=False):
@@ -2118,7 +2128,7 @@ class Fitter:
         if lpenalty is not None:
             l = l + lpenalty
 
-        lext = self._compute_external_nll()
+        lext = self._compute_external_nll(full_nll=full_nll)
         if lext is not None:
             l = l + lext
         return l

--- a/rabbit/tensorwriter.py
+++ b/rabbit/tensorwriter.py
@@ -1350,12 +1350,14 @@ class TensorWriter:
             )
         return np.array([ax.value(i) for i in range(len(ax))], dtype=object)
 
-    def add_external_likelihood_term(self, grad=None, hess=None, name=None):
+    def add_external_likelihood_term(
+        self, grad=None, hess=None, name=None, mean=None, const=None, lognorm=None
+    ):
         """Add an additive quadratic term to the negative log-likelihood.
 
         The term has the form
 
-            L_ext(x) = g^T x_sub + 0.5 * x_sub^T H x_sub
+            L_ext(x) = g^T x_sub + 0.5 * x_sub^T H x_sub + const  [+ lognorm]
 
         where ``x_sub`` is the slice of the full fit parameter vector
         corresponding to the parameters identified by the StrCategory axes
@@ -1364,11 +1366,20 @@ class TensorWriter:
         strings and resolved against the full parameter list (POIs + systs)
         at fit time.
 
+        To declare a Gaussian prior ``N(mu, C)``, the recommended form is to
+        pass ``hess`` (= ``C^-1``) together with ``mean`` and let this method
+        derive ``grad = -H mu`` and the scalars for you. Building ``grad``
+        yourself works too, but then a *dense* ``hess`` is required for the
+        scalars to be derived automatically at load time -- with a sparse
+        ``hess`` there is no cheap way to recover ``mu`` from ``g``, and the
+        term stays uncentered. See :mod:`rabbit.external_likelihood`.
+
         Parameters
         ----------
         grad : hist.Hist, optional
             1D histogram with one ``hist.axis.StrCategory`` axis whose bin
             labels are parameter names. Values are the gradient ``g``.
+            Mutually exclusive with ``mean``.
         hess : hist.Hist or wums.SparseHist, optional
             2D histogram with two ``hist.axis.StrCategory`` axes; both must
             have identical bin labels equal to the gradient parameter list
@@ -1379,11 +1390,40 @@ class TensorWriter:
         name : str, optional
             Identifier for this term. Auto-generated if not provided.
             Multiple terms can be added by calling this method repeatedly.
+        mean : hist.Hist or array-like, optional
+            The prior mean ``mu``, in the same parameter order as ``hess``.
+            Requires ``hess`` and forbids ``grad``. Sets ``g = -H mu`` and
+            ``const = 0.5 mu^T H mu``; the latter needs only a matvec, so
+            this is also the way to get a *sparse* Gaussian term centered
+            correctly. If a 1D ``hist.Hist`` is given its axis labels are
+            checked against the Hessian's.
+        const : float, optional
+            Override for the centering constant ``0.5 mu^T H mu``. Rarely
+            needed; use ``mean`` instead. Passing ``0.0`` explicitly is
+            meaningful -- it records "this really is zero" and suppresses
+            the automatic derivation at load time.
+        lognorm : float, optional
+            Override for the Gaussian log-normalization
+            ``0.5 (k log 2pi - log det H)``, added to the full NLL only.
+            Supply this for a sparse Gaussian term if you want
+            ``nllvalfull`` to be a true -log L; it is not derived from a
+            sparse Hessian automatically.
         """
         if grad is None and hess is None:
             raise ValueError(
                 "add_external_likelihood_term requires at least one of grad or hess"
             )
+        if mean is not None:
+            if hess is None:
+                raise ValueError(
+                    "add_external_likelihood_term: mean= requires hess= "
+                    "(the prior mean is only meaningful together with H = C^-1)"
+                )
+            if grad is not None:
+                raise ValueError(
+                    "add_external_likelihood_term: pass either mean= or grad=, "
+                    "not both (grad is derived as -H mu when mean is given)"
+                )
 
         if name is None:
             name = f"ext{len(self.external_terms)}"
@@ -1459,6 +1499,43 @@ class TensorWriter:
                         f"params length {len(params)}"
                     )
 
+        # Gaussian prior declared as (H, mu): derive g = -H mu and the centering
+        # constant 0.5 mu^T H mu. Both need only a matvec, so this path works
+        # for a sparse H too -- which the load-time derivation cannot, since
+        # recovering mu from g there would take a sparse solve.
+        if mean is not None:
+            if hasattr(mean, "axes"):
+                if len(mean.axes) != 1:
+                    raise ValueError(
+                        f"mean must be a 1D histogram, got {len(mean.axes)} axes"
+                    )
+                mean_params = self._strcategory_labels(mean.axes[0])
+                if not np.array_equal(params, mean_params):
+                    raise ValueError(
+                        "mean and hess must use the same parameter list in the "
+                        f"same order; got mean params {mean_params.tolist()} vs "
+                        f"hess params {np.asarray(params).tolist()}"
+                    )
+                mu = np.asarray(mean.values()).flatten().astype(self.dtype)
+            else:
+                mu = np.asarray(mean, dtype=self.dtype).ravel()
+                if len(mu) != len(params):
+                    raise RuntimeError(
+                        f"mean length {len(mu)} does not match params length "
+                        f"{len(params)}"
+                    )
+
+            if hess_dense is not None:
+                Hmu = hess_dense @ mu
+            else:
+                rows, cols, vals = hess_sparse
+                Hmu = np.zeros(len(params), dtype=self.dtype)
+                np.add.at(Hmu, rows, vals * mu[cols])
+
+            grad_values = (-Hmu).astype(self.dtype)
+            if const is None:
+                const = float(0.5 * mu @ Hmu)
+
         self.external_terms.append(
             {
                 "name": name,
@@ -1466,6 +1543,8 @@ class TensorWriter:
                 "grad_values": grad_values,
                 "hess_dense": hess_dense,
                 "hess_sparse": hess_sparse,
+                "const": None if const is None else float(const),
+                "lognorm": None if lognorm is None else float(lognorm),
             }
         )
 
@@ -2280,6 +2359,13 @@ class TensorWriter:
                     compression="gzip",
                 )
                 params_ds[...] = [str(p) for p in term["params"]]
+
+                # Optional Gaussian scalars. Written only when known, so that
+                # "absent" keeps meaning "derive it at load time if you can"
+                # and existing files stay readable unchanged.
+                for key in ("const", "lognorm"):
+                    if term.get(key) is not None:
+                        term_group.create_dataset(key, data=float(term[key]))
 
                 if term["grad_values"] is not None:
                     nbytes += h5pyutils_write.writeFlatInChunks(

--- a/tests/test_external_nll_constant.py
+++ b/tests/test_external_nll_constant.py
@@ -1,0 +1,259 @@
+"""Test that an external likelihood term evaluates to a *proper* Gaussian.
+
+An external term is stored expanded,
+
+    -log L_ext = g^T x + 0.5 x^T H x   (+ const [+ lognorm])
+
+so for a Gaussian prior N(mu, C) with H = C^-1 and g = -H mu it is short by
+two additive scalars relative to the real thing:
+
+    const   = 0.5 mu^T H mu                     -- centers the quadratic, i.e.
+                                                   makes the term 0 at x = mu
+    lognorm = 0.5 (k log 2pi - log det H)       -- normalizes the density
+
+Without ``const`` the term reads -0.5 mu^T H mu at the prior mean, so every
+absolute NLL on a card carrying an external term is offset by a card-dependent
+amount -- invisible in any NLL *difference* taken within one fit (which is why
+fits were always right) but wrong in ``nllvalreduced``, ``nllvalfull`` and the
+saturated chi2 built as ``2 * nllvalreduced``.
+
+The decisive check here compares two cards that are identical except for the
+presence of the term, and asserts that the loss difference equals the analytic
+Gaussian evaluated in numpy -- at several points, not just the minimum. That
+is what pins both scalars; asserting only the postfit parameter value (as
+test_external_term.py does) cannot see a constant at all.
+"""
+
+import os
+import tempfile
+
+import numpy as np
+from test_external_term import (
+    build_writer,
+    loss_grad_hess_at,
+    make_grad_hist,
+    make_hess_hist,
+    make_hess_sparsehist,
+)
+
+from rabbit import external_likelihood
+
+PARAM = "shape"  # the single systematic in build_writer's model
+TOL = 1e-9
+
+
+def write(tmpdir, fname, **kwargs):
+    """Build the standard test card, optionally with an external term."""
+    writer = build_writer()  # no term; we add it ourselves to control kwargs
+    if kwargs:
+        writer.add_external_likelihood_term(**kwargs)
+    path = os.path.join(tmpdir, fname)
+    writer.write(outfolder=tmpdir, outfilename=fname)
+    return path
+
+
+def loss_at(filename, parms_ref, value, full=False):
+    """Loss of ``filename`` with PARAM set to ``value``, everything else at 0."""
+    import tensorflow as tf
+    from test_external_term import make_options
+
+    from rabbit import fitter, inputdata
+    from rabbit.param_models.helpers import load_model
+
+    indata_obj = inputdata.FitInputData(filename)
+    f = fitter.Fitter(indata_obj, load_model("Mu", indata_obj), make_options())
+    f.set_nobs(f.expected_yield())
+    x = f.x.numpy().copy()
+    x[int(np.where(f.parms.astype(str) == PARAM)[0][0])] = value
+    f.x.assign(tf.constant(x, dtype=f.x.dtype))
+    return float((f.full_nll() if full else f.reduced_nll()).numpy())
+
+
+def test_gaussian_scalars_closed_form():
+    """0.5 g^T H^-1 g must equal 0.5 mu^T H mu, and the degenerate cases must
+    not raise."""
+    rng = np.random.default_rng(0)
+    A = rng.normal(size=(3, 3))
+    H = A @ A.T + 3 * np.eye(3)  # symmetric positive definite
+    mu = np.array([0.7, -1.3, 0.2])
+    g = -H @ mu
+
+    const, lognorm = external_likelihood.gaussian_scalars(g, H, "t")
+    assert abs(const - 0.5 * mu @ H @ mu) < 1e-12, "const != 0.5 mu^T H mu"
+    _, logdet = np.linalg.slogdet(H)
+    assert abs(lognorm - 0.5 * (3 * np.log(2 * np.pi) - logdet)) < 1e-12
+
+    # no hessian -> a linear tilt, no minimum, nothing to center
+    assert external_likelihood.gaussian_scalars(g, None, "t") == (0.0, 0.0)
+    # no gradient -> already centered at the origin
+    c0, ln0 = external_likelihood.gaussian_scalars(None, H, "t")
+    assert c0 == 0.0 and abs(ln0 - lognorm) < 1e-12
+    # singular H -> pseudo-inverse path, must not raise
+    Hs = np.diag([2.0, 0.0])
+    external_likelihood.gaussian_scalars(np.array([1.0, 0.0]), Hs, "t")
+    # indefinite H -> centering defined, normalization is not
+    _, ln_bad = external_likelihood.gaussian_scalars(
+        np.array([1.0, 0.0]), np.diag([2.0, -1.0]), "t"
+    )
+    assert ln_bad == 0.0, "indefinite H must not get a log-normalization"
+    print("  test_gaussian_scalars_closed_form OK")
+
+
+def test_term_equals_analytic_gaussian(sparse=False):
+    """loss(with term) - loss(without term) == the analytic Gaussian."""
+    mu_val, sigma = 0.6, 0.25
+    H = np.array([[1.0 / sigma**2]])
+    g = -H @ np.array([mu_val])
+    make_hess = make_hess_sparsehist if sparse else make_hess_hist
+
+    with tempfile.TemporaryDirectory() as tmp:
+        plain = write(tmp, "plain.hdf5")
+        withterm = write(
+            tmp,
+            "ext.hdf5",
+            grad=make_grad_hist(g, [PARAM]),
+            hess=make_hess(H, [PARAM]),
+            # a sparse H cannot be auto-centered at load time, so the writer
+            # must be told the mean -- exercised properly in the mean= test.
+            **({"const": float(0.5 * mu_val**2 / sigma**2)} if sparse else {}),
+            **(
+                {"lognorm": float(0.5 * (np.log(2 * np.pi) + 2 * np.log(sigma)))}
+                if sparse
+                else {}
+            ),
+        )
+
+        for v in (0.0, mu_val, mu_val + sigma, -0.4):
+            expect = 0.5 * (v - mu_val) ** 2 / sigma**2
+            got = loss_at(withterm, None, v) - loss_at(plain, None, v)
+            assert abs(got - expect) < TOL, (
+                f"{'sparse' if sparse else 'dense'} reduced NLL at x={v}: "
+                f"term contributed {got}, expected {expect}"
+            )
+
+        # at the mean the term must contribute exactly zero
+        at_mu = loss_at(withterm, None, mu_val) - loss_at(plain, None, mu_val)
+        assert abs(at_mu) < TOL, f"term is {at_mu} at x=mu, must be 0"
+
+        # full NLL additionally carries the Gaussian normalization, which is
+        # the same formula _compute_lc uses per constrained parameter
+        expect_full = 0.5 * np.log(2 * np.pi) + np.log(sigma)
+        got_full = loss_at(withterm, None, mu_val, full=True) - loss_at(
+            plain, None, mu_val, full=True
+        )
+        assert (
+            abs(got_full - expect_full) < TOL
+        ), f"full NLL log-normalization: got {got_full}, expected {expect_full}"
+    print(f"  test_term_equals_analytic_gaussian(sparse={sparse}) OK")
+
+
+def test_mean_kwarg_matches_explicit_grad():
+    """hess+mean must produce exactly the same term as the hand-built grad."""
+    mu = np.array([0.6, -0.2])
+    C = np.array([[0.09, 0.02], [0.02, 0.04]])
+    H = np.linalg.inv(C)
+    params = [PARAM]  # only one real param exists; use a 1D slice for the fit
+    mu1, H1 = mu[:1], H[:1, :1]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        by_grad = write(
+            tmp,
+            "bygrad.hdf5",
+            grad=make_grad_hist(-H1 @ mu1, params),
+            hess=make_hess_hist(H1, params),
+        )
+        by_mean = write(
+            tmp,
+            "bymean.hdf5",
+            hess=make_hess_hist(H1, params),
+            mean=make_grad_hist(mu1, params),
+        )
+        for v in (0.0, 0.5, -0.3):
+            a, b = loss_at(by_grad, None, v), loss_at(by_mean, None, v)
+            assert abs(a - b) < TOL, f"mean= and grad= disagree at x={v}: {a} vs {b}"
+    print("  test_mean_kwarg_matches_explicit_grad OK")
+
+
+def test_backward_compatible_when_scalars_absent():
+    """A card whose term group has no const/lognorm must still load, and a
+    dense Hessian must be centered automatically at load time."""
+    mu_val, sigma = 0.6, 0.25
+    H = np.array([[1.0 / sigma**2]])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = write(
+            tmp,
+            "nolegacy.hdf5",
+            grad=make_grad_hist(-H @ np.array([mu_val]), [PARAM]),
+            hess=make_hess_hist(H, [PARAM]),
+        )
+        import h5py
+
+        with h5py.File(path, "r") as fh:
+            keys = set(fh["external_terms"]["ext0"].keys())
+        # nothing was stored: the derivation happens at load
+        assert "const" not in keys, f"const should not be written here, got {keys}"
+
+        terms = None
+        with h5py.File(path, "r") as fh:
+            terms = external_likelihood.read_external_terms_from_h5(
+                fh.get("external_terms")
+            )
+        assert terms[0]["const"] is None, "absent const must read back as None"
+
+        built = external_likelihood.build_tf_external_terms(
+            terms, np.array([PARAM]), __import__("tensorflow").float64
+        )
+        expect = 0.5 * mu_val**2 / sigma**2
+        assert (
+            abs(built[0]["const"] - expect) < 1e-10
+        ), f"load-time derivation gave {built[0]['const']}, expected {expect}"
+    print("  test_backward_compatible_when_scalars_absent OK")
+
+
+def test_scalars_do_not_move_the_fit():
+    """The scalars are constants, so they must not touch any derivative.
+
+    Asserted as a difference against the term-free card, which isolates the
+    term's own contribution from the data and native-constraint curvature
+    that both cards share. At the default start (x = 0) the term contributes
+    gradient ``g + H x = -H mu`` and Hessian ``H`` exactly.
+    """
+    mu_val, sigma = 0.6, 0.25
+    H = np.array([[1.0 / sigma**2]])
+    with tempfile.TemporaryDirectory() as tmp:
+        plain = write(tmp, "plain.hdf5")
+        withterm = write(
+            tmp,
+            "ext.hdf5",
+            grad=make_grad_hist(-H @ np.array([mu_val]), [PARAM]),
+            hess=make_hess_hist(H, [PARAM]),
+        )
+        parms_a, _, grad_a, hess_a = loss_grad_hess_at(plain)
+        parms_b, _, grad_b, hess_b = loss_grad_hess_at(withterm)
+        i = int(np.where(parms_b == PARAM)[0][0])
+        j = int(np.where(parms_a == PARAM)[0][0])
+
+        dgrad = grad_b[i] - grad_a[j]
+        dhess = hess_b[i, i] - hess_a[j, j]
+        assert (
+            abs(dgrad - (-mu_val / sigma**2)) < 1e-8
+        ), f"term changed the gradient by {dgrad}, expected {-mu_val / sigma**2}"
+        assert (
+            abs(dhess - 1.0 / sigma**2) < 1e-8
+        ), f"term changed the hessian by {dhess}, expected {1.0 / sigma**2}"
+    print("  test_scalars_do_not_move_the_fit OK")
+
+
+def main():
+    test_gaussian_scalars_closed_form()
+    test_term_equals_analytic_gaussian(sparse=False)
+    test_term_equals_analytic_gaussian(sparse=True)
+    test_mean_kwarg_matches_explicit_grad()
+    test_backward_compatible_when_scalars_absent()
+    test_scalars_do_not_move_the_fit()
+    print("all external-nll-constant tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The problem

An external likelihood term is stored expanded, exactly as its docstring says:

```
-log L_ext = g^T x_sub + 0.5 x_sub^T H x_sub
```

For a Gaussian prior `N(mu, C)` with `H = C^-1` and `g = -H mu`, the real thing is `0.5 (x-mu)^T H (x-mu) + lognorm`, and expanding it gives

```
0.5 (x-mu)^T H (x-mu)  =  g^T x + 0.5 x^T H x  +  0.5 mu^T H mu
```

So the stored form is short by `const = 0.5 mu^T H mu`, and separately by the Gaussian normalisation. It evaluates to `-0.5 mu^T H mu` at the prior mean instead of `0`.

**How this surfaced.** On a card with a 2-parameter lattice prior the offset is 62.4 units. That made a *penalised* fit appear to have a lower NLL (4373.45) than its own unpenalised version (4433.12) — impossible, since adding a penalty can only raise the minimum. We had been correcting it by hand.

## Blast radius

**No fit changes.** Neither scalar depends on `x`, so the minimum, gradient, Hessian, covariance, EDM, impacts, scans and every NLL *difference* taken within a single fit are untouched. That is why fits have always been correct and only reported numbers were wrong.

**What was wrong:** `nllvalreduced`, `nllvalfull`, and `chi2_val = 2.0 * nllvalreduced` in `rabbit_fit.py` (the absolute saturated chi2), which was off by `2 * const`.

## Where each scalar goes

Following `_compute_lc`, which writes the native constraint term in centered form `cw * 0.5 * (x - x0)^2` and gates only its normalisation on `full_nll`:

| scalar | value | included in |
|---|---|---|
| `const` | `0.5 mu^T H mu` = `0.5 g^T H^-1 g` | reduced **and** full — it is part of the quadratic, not a normalisation |
| `lognorm` | `0.5 (k log 2pi - log det H)` | full only |

`lognorm` in one dimension is exactly the `0.9189 + log(sigma)` that `_compute_lc` already adds per constrained parameter. So on a card mixing native constraints with an external term, `nllvalfull` was previously normalising some priors and not others.

## Migration: none

Both scalars are derived at load time when `H` is dense, so **existing cards are fixed with no regeneration and no re-fitting**. Verified against a real card: the 62.408046 we had been adding by hand is now produced automatically, and the term evaluates to exactly 0 at `mu`.

A sparse `H` would need a sparse solve and log-determinant, neither of which belongs in a load path — those terms keep today's behaviour with a warning and must be given the scalars at write time. To that end `add_external_likelihood_term()` gains **`mean=`**, which derives `g = -H mu` and `const = 0.5 mu^T H mu` from a single matvec (no solve needed when `mu` is known) and is the recommended way to declare a Gaussian prior. `const=` / `lognorm=` overrides exist for the raw-sparse case.

## Degenerate cases

The `g^T x + 0.5 x^T H x` form can express things that are not priors, so these are handled explicitly rather than raising:

- **grad only** (`H` absent) — a linear tilt with no minimum; nothing to centre, nothing added
- **grad zero** — already centred; `const = 0` exactly
- **singular `H`** — pseudo-inverse for the constrained subspace; warns if `g` has a component outside `range(H)`, where the term is unbounded below and no constant centres it
- **non-positive-definite `H`** — not a density; centred but not normalised, with a warning

## Tests

New `tests/test_external_nll_constant.py` compares two cards identical but for the term and asserts the loss difference equals the analytic Gaussian **at several points, not just the minimum** — the existing `test_external_term.py` asserts only postfit parameter values, which by construction cannot see a constant. Also covers the `mean=` path, sparse storage, backward compatibility when the scalars are absent, the degenerate cases, and that gradient/Hessian are unchanged.

Both the new suite and the existing `test_external_term.py` pass. `black` / `isort` / `flake8` run with the CI flags in the CI container image are clean repo-wide.

## Note for reviewers

Absolute NLL values change for any card carrying an external term. That is the fix, but it will look like a regression to anyone diffing against previous output, so it may be worth a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnJ9YKK8c1q1sCDouM6y1c