### PR TITLE
Re-arm regularizers when the parameter layout changes (saturated GoF was unwalled)

### DIFF
--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -442,10 +442,17 @@ def save_hists(args, mappings, fitter, ws, prefit=True, profile=False):
                 fitter_saturated.tau.assign(saved_tau)
 
                 fitter_saturated.xdefaultassign()
+                # The composite re-init reordered and resized the parameter
+                # vector (one POI per projected bin, inserted ahead of the
+                # original model's block), so regularizers must be re-armed or
+                # they read the wrong entries. xdefaultassign() above is
+                # deliberate but does not arm them.
+                fitter_saturated.arm_regularizers()
                 cb = fitter_saturated.minimize()
+                cov_saturated = None
                 if not args.noHessian:
                     _, grad, hess = fitter_saturated.loss_val_grad_hess()
-                    edmval, cov = fitter_saturated.edmval_cov(grad, hess)
+                    edmval, cov_saturated = fitter_saturated.edmval_cov(grad, hess)
                     logger.info(f"edmval: {edmval}")
                 else:
                     edmval = None
@@ -464,6 +471,28 @@ def save_hists(args, mappings, fitter, ws, prefit=True, profile=False):
                 ws.add_chi2(
                     chi2val, ndf, prefit, mapping, saturated=True, edmval=edmval
                 )
+
+                # Persist the saturated fit itself, not just its chi2, under
+                # results["mappings"][<mapping>]["saturated_fit"], using the same
+                # key names the primary fit uses at top level.
+                SAT = dict(mapping_key=mapping.key, group="saturated_fit")
+                ws.add_value(float(nllvalreduced), "nllvalreduced", **SAT)
+                ws.add_named_parms_hist(
+                    fitter_saturated.x.numpy(),
+                    fitter_saturated.parms,
+                    variances=(
+                        np.diag(cov_saturated) if cov_saturated is not None else None
+                    ),
+                    **SAT,
+                )
+                ws.add_minimizer_status(fitter_saturated.minimizer_status(), **SAT)
+                if edmval is not None:
+                    ws.add_value(float(edmval), "edmval", **SAT)
+                if cov_saturated is not None:
+                    ws.add_named_cov_hist(cov_saturated, fitter_saturated.parms, **SAT)
+                if cb is not None and getattr(cb, "loss_history", None) is not None:
+                    ws.add_1D_integer_hist(cb.loss_history, "epoch", "loss", **SAT)
+                    ws.add_1D_integer_hist(cb.time_history, "epoch", "time", **SAT)
 
         if args.saveHistsPerProcess and not mapping.skip_per_process:
             logger.info(f"Save processes histogram for {mapping.key}")

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -125,6 +125,9 @@ class Fitter:
         self.minimizer_maxiter = getattr(options, "minimizerMaxiter", None)
         self.minimizer_gtol = getattr(options, "minimizerGtol", None)
         self.minimizer_ftol = getattr(options, "minimizerFtol", None)
+        # scipy's OptimizeResult from the last fit(), so the convergence
+        # outcome can be written to the output. None if the minimizer raised.
+        self.minimizer_result = None
         self.hvp_method = getattr(options, "hvpMethod", "revrev")
         # jitCompile accepts "auto" (the default), "on", or "off".
         # True / False from programmatic callers are accepted as
@@ -273,6 +276,10 @@ class Fitter:
             self.init_blinding_values(unblind, blinding_group)
 
         self.parms = np.concatenate([self.param_model.params, self.indata.systs])
+        # Layout changed: anything a regularizer resolved is now stale. Marked
+        # rather than re-armed here because this runs from __init__, before
+        # regularizers are attached; discharged by arm_regularizers().
+        self._regularizers_armed = False
 
         # tf tensor containing default constraint minima
         theta0default = np.zeros(self.indata.nsyst)
@@ -809,10 +816,19 @@ class Fitter:
         if self.do_blinding:
             self.set_blinding_offsets(False)
 
+        self.arm_regularizers()
+
+    def arm_regularizers(self):
+        """Tell every regularizer about the current parameter layout.
+
+        Must be called after anything that changes ``self.parms``, notably
+        ``init_fit_parms``.
+        """
         xinit = self.get_x()
         nexp0 = self.expected_yield(full=True)
         for reg in self.regularizers:
-            reg.set_expectations(xinit, nexp0)
+            reg.set_expectations(xinit, nexp0, parms=self.parms)
+        self._regularizers_armed = True
 
     def bayesassign(self):
         # Sample the parameter values from their priors: width sqrt(1/cw)
@@ -2089,6 +2105,11 @@ class Fitter:
         lbeta = self._compute_lbeta(beta, full_nll)
 
         if len(self.regularizers):
+            if not getattr(self, "_regularizers_armed", False):
+                raise RuntimeError(
+                    "Regularizers not armed against the current parameter layout; "
+                    "call arm_regularizers() (or defaultassign()) first."
+                )
             x = self.get_x()
             penalties = [
                 reg.compute_nll_penalty(x, nexpfullcentral) * tf.exp(2 * self.tau)
@@ -2314,14 +2335,33 @@ class Fitter:
             # minimizer could have called the loss or hessp functions with "random" values, so restore the
             # state from the end of the last iteration before the exception
             xval = callback.xval
+            self.minimizer_result = None
             logger.debug(ex)
         else:
             xval = res["x"]
+            self.minimizer_result = res
             logger.debug(res)
 
         self.x.assign(xval)
 
         return callback
+
+    def minimizer_status(self):
+        """Convergence outcome of the last :meth:`fit`, or None if none ran.
+
+        NB ``success`` is scipy's flag, not a convergence test on its own:
+        BFGS reports False ("precision loss") at points with EDM ~1e-17.
+        """
+        res = self.minimizer_result
+        if res is None:
+            return None
+        return {
+            "success": bool(getattr(res, "success", False)),
+            "status": int(getattr(res, "status", -1)),
+            "nit": int(getattr(res, "nit", -1)),
+            "nfev": int(getattr(res, "nfev", -1)),
+            "message": str(getattr(res, "message", "")),
+        }
 
     def minimize(self):
         if self.is_linear:

--- a/rabbit/regularization/regularizer.py
+++ b/rabbit/regularization/regularizer.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 class Regularizer:
 
     def __init__(self, mapping, dtype):
@@ -5,9 +8,14 @@ class Regularizer:
         Initialize the regularization depending on the mapping
         """
 
-    def set_expectations(self, initial_params, initial_observables):
+    def set_expectations(self, initial_params, initial_observables, parms=None):
         """
-        Set the expectations to use in the regularization, this step should be called once per fit configuration
+        Set the expectations to use in the regularization. Called once per
+        parameter layout: the fitter can swap its ParamModel mid-session (the
+        saturated goodness-of-fit path wraps it in a CompositeParamModel), which
+        reorders and resizes the parameter vector. Do not cache positions across
+        calls; re-resolve them by name from ``parms``, the names of every entry
+        of ``initial_params``.
         """
 
     def compute_nll_penalty(self, params, observables):
@@ -15,3 +23,17 @@ class Regularizer:
         Compute the penalty term that gets added to -ln(L), this function should be called in each step of the minimization
         """
         return 0
+
+    @staticmethod
+    def resolve_indices(parms, names, who="Regularizer"):
+        """Map parameter names to positions in ``parms``, raising if any is absent."""
+        if parms is None:
+            raise ValueError(
+                f"{who}: parameter names are required to resolve positions"
+            )
+        parms = np.asarray(parms).astype(str)
+        index = {name: i for i, name in enumerate(parms)}
+        missing = [n for n in names if n not in index]
+        if missing:
+            raise ValueError(f"{who}: {missing} not in the fit's parameter vector")
+        return {n: index[n] for n in names}

--- a/rabbit/regularization/svd.py
+++ b/rabbit/regularization/svd.py
@@ -52,7 +52,9 @@ class SVD(Regularizer):
 
         self.paddings = [[0, 0]] + [[1, 1]] * self.ndims + [[0, 0]]
 
-    def set_expectations(self, initial_params, initial_observables):
+    def set_expectations(self, initial_params, initial_observables, parms=None):
+        # parms is unused here: this regularizer holds no per-parameter positions,
+        # it works through self.mapping, which is rebuilt from the current vector.
         # TODO: do we need to include this in autodiff for global impacts, since initial_params = (poi0, theta0)?
         nexp0 = self.mapping.compute_flat(initial_params, initial_observables)
         self.nexp0 = tf.reshape(nexp0, self.input_shape)

--- a/rabbit/workspace.py
+++ b/rabbit/workspace.py
@@ -117,7 +117,7 @@ class Workspace:
             file_path = f"{parts[0]}_{postfix}.{parts[1]}"
         return file_path
 
-    def dump_obj(self, obj, key, mapping_key=None, channel=None):
+    def dump_obj(self, obj, key, mapping_key=None, channel=None, group=None):
         result = self.results
 
         if mapping_key is not None:
@@ -133,6 +133,13 @@ class Workspace:
             if channel not in result["channels"]:
                 result["channels"][channel] = {}
             result = result["channels"][channel]
+
+        # One further, freely-named level, so a second fit's results can sit
+        # beside the primary one under the same key names.
+        if group is not None:
+            if group not in result:
+                result[group] = {}
+            result = result[group]
 
         result[key] = obj
 
@@ -190,6 +197,7 @@ class Workspace:
         label=None,
         channel=None,
         mapping_key=None,
+        group=None,
         is_matrix=False,
         flow=False,
     ):
@@ -208,7 +216,7 @@ class Workspace:
                     variances = variances[start:stop]
 
         h = self.hist(name, axes, values, variances, label, flow=flow)
-        self.dump_hist(h, mapping_key, channel)
+        self.dump_hist(h, mapping_key, channel, group=group)
 
     def add_value(self, value, name, *args, **kwargs):
         self.dump_obj(value, name, *args, **kwargs)
@@ -221,6 +229,42 @@ class Workspace:
         self.add_value(float(chi2), "chi2" + postfix, mapping.key)
         if edmval is not None:
             self.add_value(float(edmval), "edmval" + postfix, mapping.key)
+
+    def add_minimizer_status(self, status, name="minimizer_status", *args, **kwargs):
+        """Store a :meth:`Fitter.minimizer_status` dict (no-op if ``None``)."""
+        if status is not None:
+            self.add_value(dict(status), name, *args, **kwargs)
+
+    @staticmethod
+    def _parms_axis(parms, name="parms"):
+        return hist.axis.StrCategory(
+            [p.decode() if isinstance(p, bytes) else str(p) for p in parms], name=name
+        )
+
+    def add_named_parms_hist(
+        self, values, parms, hist_name="parms", variances=None, **kwargs
+    ):
+        """Store a postfit parameter vector carrying its own parameter list,
+        for a fit whose model differs from the primary one."""
+        if variances is None:
+            variances = np.full(len(values), np.nan)
+        self.add_hist(
+            hist_name,
+            self._parms_axis(parms),
+            np.asarray(values),
+            variances=variances,
+            **kwargs,
+        )
+
+    def add_named_cov_hist(self, cov, parms, hist_name="cov", **kwargs):
+        """:meth:`add_cov_hist` for a fit with its own parameter list."""
+        self.add_hist(
+            hist_name,
+            [self._parms_axis(parms, "parms_x"), self._parms_axis(parms, "parms_y")],
+            cov,
+            is_matrix=True,
+            **kwargs,
+        )
 
     def add_observed_hists(
         self,
@@ -587,12 +631,16 @@ class Workspace:
 
         return name, label
 
-    def add_1D_integer_hist(self, values, name_x, name_y):
+    def add_1D_integer_hist(self, values, name_x, name_y, **kwargs):
         axis_epoch = hist.axis.Integer(
             0, len(values), underflow=False, overflow=False, name=name_x
         )
         self.add_hist(
-            f"{name_x}_{name_y}", axis_epoch, values, label=f"{name_x} {name_y}"
+            f"{name_x}_{name_y}",
+            axis_epoch,
+            values,
+            label=f"{name_x} {name_y}",
+            **kwargs,
         )
 
     def write_meta(self, meta):


### PR DESCRIPTION
Separate from #147 — that one is about the external-term constant, this one is about regularizers reading the wrong parameters.

## The bug

A regularizer that resolves a parameter *position* is only correct for the layout it resolved against — and the layout is **not stable within a fit session**. The saturated goodness-of-fit path swaps the model for `CompositeParamModel([original, SaturatedProjectModel])`, whose `[poi(m1), poi(m2), ..., pou(m1), pou(m2), ...]` ordering inserts one POI **per projected bin ahead of** the original model's block. In a 2D ptll × yll SCETlib fit that displaces all 7 λ by 39 positions.

Nothing tells the regularizers. `rabbit_fit.py` restores `regularizers` after the composite re-init but never re-arms them, and the arming loop lives in `Fitter.defaultassign()` — which that path doesn't call. It calls `xdefaultassign()`, deliberately, so the saturated fit starts from the parameter defaults.

For WRemnants' `NPDampingWall`, which caches positions at construction, the effect was:

```
wall asks for      reads index   which now holds           value
lambda2_nu              0        saturated_ch0_ptll0      +0.935
lambda4_nu              1        saturated_ch0_ptll1      +0.940
lambda_inf_nu           2        saturated_ch0_ptll2      +0.939
...
```

Per-bin factors near 1.0, far above the wall's 0.005 margin — so every condition was trivially satisfied and the penalty was **identically zero**. The saturated *reference* ran unwalled while the *nominal* fit it is compared against was walled: a likelihood ratio whose two halves had different objectives. The reference duly parked at `lambda2_nu = -0.231`, a point that costs **1225 nll units** once the wall is applied.

## Impact on results

Measured on 2D real-data fits — same card, same minimiser, same start, only the wall now readable:

| fit | chi²/39 before | after | p before | p after |
|---|---|---|---|---|
| MSHT20 prior-free | 47.58 | 62.11 | 16.28% | 1.07% |
| MSHT20 lattice cov | 33.44 | 65.56 | 72.10% | 0.49% |
| CT18Z prior-free | 57.19 | 56.29 | 3.01% | 3.60% |

Directly verified: the broken reference's postfit `lambda2_nu = -0.23081` (wall would charge 1224.8); the fixed one lands at `+0.00488`, resting on the 0.005 margin, with the wall charging **0.000**.

## There was already a guard

`set_expectations` has a width check whose comment names this exact scenario ("a wrapping/composite param model (e.g. the saturated goodness-of-fit path) reorders/resizes the block in a way this wall's flat indexing cannot follow"). It never fired, because it sits on a code path the saturated fit doesn't take.

Related: `7bd0d81` fixed the **x0** permutation for this same layout; the line directly below it re-points `regularizers` without rebinding them.

## Changes

- `Regularizer.set_expectations` gains **`parms`** (names of the current vector), defaulted to `None` so existing implementations keep working. Docstring now states the layout can be reordered and resized mid-session and that positions must not be cached — it previously said "called once per fit configuration", which reads as an invitation to cache.
- **`Regularizer.resolve_indices(parms, names)`** resolves by name and raises on a missing name, so the easy path is the correct one.
- **`Fitter.arm_regularizers()`** passes `self.parms`; `defaultassign()` delegates to it; `rabbit_fit.py` calls it after the composite re-init.
- **Staleness tripwire**: `init_fit_parms` marks regularizers stale; `_compute_nll_components` refuses to evaluate a penalty while they are. A future path that changes the layout and forgets to re-arm crashes instead of silently applying each regularizer to whatever sits at its old positions.

## Also included: persisting the saturated fit

Under `results["mappings"][<mapping>]["saturated_fit"]`, using the same key names the primary fit uses at top level (`parms` / `nllvalreduced` / `edmval` / `cov` / `epoch_loss` / `minimizer_status`), so a reader can treat the sub-group exactly like the main results dict.

Previously that fit's entire state was discarded and only its chi² survived, which made ordinary questions unanswerable from the files: where the reference put its parameters (the `parms` beside the chi² are the **nominal** ones echoed back by the outer `--noFit` pass); which bins the model misses (the saturated POIs are one per projected bin, so their postfit values are a per-bin residual map); whether the reference converged (this step runs `--noHessian`, so no `edmval`, and scipy's outcome was `logger.debug`-only); and what `nll_sat` is (recoverable only by inverting the chi² definition).

A few tens of kB against a ~100 MB cov. It's in this PR because it is what made the bug visible.

## Notes for reviewers

- **This changes published goodness-of-fit numbers** for any walled fit. That is the fix, but it will look like a regression to anyone diffing.
- `svd.py` needs no logic change (it holds no per-parameter positions); its signature is widened for interface compatibility.
- Tests: `tests/test_regularizer_layout.py` covers name resolution across two layouts, refusal to guess on a missing name or absent `parms`, and the backward-compatible signature.
- Lint: `black` / `isort --profile black` / `flake8` with the CI flags, run in the CI container image, clean repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnJ9YKK8c1q1sCDouM6y1c