### PR TITLE
Support the saturated likelihood test for any selection mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Custom models are loaded by providing a dotted Python path (e.g. `--paramModel m
 
 ### Mappings: `rabbit/mappings/`
 Base class `Mapping` in `mapping.py` defines `compute_flat(params, observables)`, which is a differentiable transformation of the flat bin vector. The framework propagates uncertainties through it via automatic differentiation (`tf.GradientTape`). Built-in mappings (`Select`, `Project`, `Normalize`, `Ratio`, `Normratio`) live in `project.py` and `ratio.py`. Custom mappings follow the same pattern as param models.
+Mappings that are a plain selection and summation of input bins (`Select`, `Project`) also implement `output_indices()`, returning the flat output-bin index each input bin contributes to (`-1` if unused). This is what `--computeSaturatedProjectionTests` uses to build a `SaturatedProjectModel` (one free parameter per output bin, applied to the input bins feeding it); mappings that are not of this form return `None` and are skipped.
 
 ### Bin scripts: `bin/`
 Entry points registered in `pyproject.toml`. The main one is `rabbit_fit.py`; others are diagnostic/plotting scripts. All use `rabbit/parsing.py` for shared CLI arguments.

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ The first argument is the mapping name followed by arguments passed into the map
 Available mappings are:
  * `BaseMapping`: Compute histograms in all bins and all channels.
  * `Select`: To select histograms of a channel, and perform a selection of processes and bins, supporting rebinning.
- * `Project`: To project histograms to lower dimensions, respecting the covariance matrix across bins.
- * `Normalize`: To normalize histograms to their sum (and project them) e.g. to compute normalized differential cross sections.
+ * `Project`: To project histograms to lower dimensions, respecting the covariance matrix across bins. It is a `Select` where all axes of the channel that are not listed are summed, but the resulting axes follow the order in which they are requested.
+ * `Normalize`: Same as `Project` but the result is normalized to its integral e.g. to compute normalized differential cross sections.
  * `Ratio`: To compute the ratio between channels, processes, or histogram bins.
  * `Normratio`: To compute the ratio of normalized histograms.
 

--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -28,7 +28,6 @@ from scipy.stats import chi2
 from rabbit import fitter, inputdata, parsing, workspace
 from rabbit.mappings import helpers as mh
 from rabbit.mappings import mapping as mp
-from rabbit.mappings import project
 from rabbit.param_models import helpers as ph
 from rabbit.param_models import param_model
 from rabbit.regularization import helpers as rh
@@ -161,7 +160,8 @@ def make_parser():
         "--computeSaturatedProjectionTests",
         default=False,
         action="store_true",
-        help="Compute the saturated likelihood test for Project mappings",
+        help="Compute the saturated likelihood test for mappings that are a selection "
+        "and a summation of input bins, e.g. 'Select' and 'Project' mappings",
     )
     parser.add_argument(
         "--noChi2",
@@ -394,15 +394,21 @@ def save_hists(args, mappings, fitter, ws, prefit=True, profile=False):
 
                 ws.add_chi2(chi2val, ndf, prefit, mapping)
 
-            if (
-                not prefit
-                and type(mapping) == project.Project
-                and args.computeSaturatedProjectionTests
-            ):
+            # the saturated model is only defined for mappings that are a selection and a
+            #   summation of input bins, and needs data to compare the prediction against
+            saturated_indices = (
+                mapping.output_indices()
+                if args.computeSaturatedProjectionTests
+                and not prefit
+                and mapping.has_data
+                else None
+            )
+
+            if saturated_indices is not None:
                 # saturated likelihood test
 
                 saturated_model = param_model.SaturatedProjectModel(
-                    fitter.indata, mapping.channel_info
+                    fitter.indata, mapping.channel_info, saturated_indices
                 )
                 composite_model = param_model.CompositeParamModel(
                     [fitter.param_model, saturated_model]
@@ -450,12 +456,20 @@ def save_hists(args, mappings, fitter, ws, prefit=True, profile=False):
                 fitter_saturated.arm_regularizers()
                 cb = fitter_saturated.minimize()
                 cov_saturated = None
+                edmval = None
                 if not args.noHessian:
                     _, grad, hess = fitter_saturated.loss_val_grad_hess()
-                    edmval, cov_saturated = fitter_saturated.edmval_cov(grad, hess)
-                    logger.info(f"edmval: {edmval}")
-                else:
-                    edmval = None
+                    try:
+                        edmval, cov_saturated = fitter_saturated.edmval_cov(grad, hess)
+                        logger.info(f"edmval: {edmval}")
+                    except (ValueError, np.linalg.LinAlgError) as e:
+                        # the saturated parameters can be degenerate with parameters of the
+                        #   original model, e.g. if a parameter only affects bins that are
+                        #   made free by the saturated model. The test statistic itself does
+                        #   not need the hessian and stays valid.
+                        logger.warning(
+                            f"Could not compute the covariance of the saturated fit for '{mapping.key}': {e}"
+                        )
 
                 nllvalreduced = fitter_saturated.reduced_nll().numpy()
 

--- a/rabbit/mappings/helpers.py
+++ b/rabbit/mappings/helpers.py
@@ -98,8 +98,10 @@ class Term:
 
         self.has_data = not info.get("masked", False) and len(processes) == 0
 
-        flow = info.get("flow", False)
-        self.exp_shape = tuple([a.extent if flow else a.size for a in channel_axes])
+        self.flow = info.get("flow", False)
+        self.exp_shape = tuple(
+            [a.extent if self.flow else a.size for a in channel_axes]
+        )
 
         if processes is not None:
             if any(p not in indata.procs.astype(str) for p in processes):
@@ -160,6 +162,47 @@ class Term:
         self.sum_idxs = [i for i, n in enumerate(h.axes.name) if n in sum_axes]
 
         self.channel_axes = channel_axes
+
+    @property
+    def out_shape(self):
+        """shape of the output of 'select'"""
+        return tuple(a.extent if self.flow else a.size for a in self.channel_axes)
+
+    def output_indices(self):
+        """
+        For each bin of the channel, the flat index of the bin in the output of 'select'
+        it contributes to, and -1 for bins that do not enter the output at all.
+        Mirrors the operations of 'select' for the inclusive case,
+        i.e. sum(values[indices == i]) == select(values).flat[i]
+        """
+        # coordinate of each bin along each axis in the output, -1 for bins that are dropped
+        coords = []
+        sizes = []
+        for i, n in enumerate(self.exp_shape):
+            c = np.full(n, -1, dtype=np.int64)
+            s = self.selections[i] if self.selections is not None else slice(None)
+            c[s] = np.arange(len(c[s]))
+            size = len(c[s])
+            if i in self.segment_ids:
+                segment_ids = self.segment_ids[i].numpy()
+                selected = c >= 0
+                c[selected] = segment_ids[c[selected]]
+                size = self.num_segments[i]
+            coords.append(c)
+            sizes.append(size)
+
+        # ravel the coordinates of the axes that are kept, bins that are dropped
+        #   along any of the axes do not enter the output
+        indices = np.zeros(self.exp_shape, dtype=np.int64)
+        selected = np.ones(self.exp_shape, dtype=bool)
+        for i, c in enumerate(coords):
+            shape = [-1 if j == i else 1 for j in range(len(self.exp_shape))]
+            c = c.reshape(shape)
+            selected &= c >= 0
+            if i not in self.sum_idxs:
+                indices = indices * sizes[i] + np.where(c >= 0, c, 0)
+
+        return np.where(selected, indices, -1).reshape(-1)
 
     def select(self, values, normalize=False, inclusive=True):
         values = values[self.start : self.stop]

--- a/rabbit/mappings/helpers.py
+++ b/rabbit/mappings/helpers.py
@@ -74,10 +74,6 @@ def parse_axis_selection(selection_str):
             if sl is not None:
                 sel[k] = sl
 
-        for s in selections:
-            if k not in sel.keys():
-                sel[k] = slice(None)
-
     return sel, rebin_axes, sum_axes
 
 
@@ -127,12 +123,8 @@ class Term:
                     for i, n in enumerate(channel_axes_names)
                 ]
             )
-            self.selection_idxs = [
-                i for i, n in enumerate(channel_axes_names) if n in selections.keys()
-            ]
         else:
             self.selections = None
-            self.selection_idxs = None
 
         # make dummy histogram to perform rebinning
         h = hist.Hist(*channel_axes)

--- a/rabbit/mappings/mapping.py
+++ b/rabbit/mappings/mapping.py
@@ -48,6 +48,14 @@ class Mapping:
     def compute_flat_per_process(self, params, observables=None):
         return self.compute_flat(params, observables)
 
+    # For mappings that are a linear selection and summation of the input bins, the flat
+    #    index of the output bin each input bin contributes to, per channel of the input data,
+    #    and -1 for input bins that do not enter the output.
+    #    Needed to build a saturated model of the output, e.g. for goodness of fit tests.
+    #    Mappings that are not of this form return None.
+    def output_indices(self):
+        return None
+
     # generic version which should not need to be overridden
     @tf.function
     def get_data(self, *args, **kwargs):
@@ -168,6 +176,8 @@ class ChannelMapping(Mapping):
     ):
         super().__init__(indata, key)
 
+        self.channel = channel
+        self.processes = processes
         self.term = helpers.Term(indata, channel, processes, **kwargs)
 
         channel_info = indata.channel_info[channel]
@@ -259,3 +269,10 @@ class Select(ChannelMapping):
 
     def compute_per_process(self, params, observables):
         return self.compute(params, observables)
+
+    def output_indices(self):
+        if self.normalize or len(self.processes):
+            # the output is not a plain sum of input bins
+            return None
+
+        return {self.channel: self.term.output_indices()}

--- a/rabbit/mappings/mapping.py
+++ b/rabbit/mappings/mapping.py
@@ -156,6 +156,8 @@ class ChannelMapping(Mapping):
     Abstract mapping to process a specific channel
     """
 
+    normalize = False  # if the result is normalized to the integral of the selection
+
     def __init__(
         self,
         indata,
@@ -187,13 +189,13 @@ class ChannelMapping(Mapping):
         return self.compute(params, observables)
 
     def compute_flat(self, params, observables):
-        exp = self.term.select(observables, inclusive=True)
+        exp = self.term.select(observables, normalize=self.normalize, inclusive=True)
         exp = self.compute(params, exp)
         exp = tf.reshape(exp, [-1])  # flatten again
         return exp
 
     def compute_flat_per_process(self, params, observables):
-        exp = self.term.select(observables, inclusive=False)
+        exp = self.term.select(observables, normalize=self.normalize, inclusive=False)
         exp = self.compute_per_process(params, exp)
         # flatten again
         flat_shape = (-1, exp.shape[-1])

--- a/rabbit/mappings/project.py
+++ b/rabbit/mappings/project.py
@@ -1,3 +1,4 @@
+import numpy as np
 import tensorflow as tf
 
 from rabbit.mappings.mapping import Select
@@ -54,6 +55,25 @@ class Project(Select):
         key = " ".join([cls.__name__, channel, *axes_names])
 
         return cls(indata, key, channel, *axes_names)
+
+    def output_indices(self):
+        indices = super().output_indices()
+        if indices is None or self.transpose_idxs == sorted(self.transpose_idxs):
+            # axes are already in the requested order
+            return indices
+
+        # index of each bin of the projection before the transposition in the transposed output
+        out_shape = self.term.out_shape
+        transposed = np.transpose(
+            np.arange(int(np.prod(out_shape))).reshape(out_shape), self.transpose_idxs
+        )
+        remap = np.empty(transposed.size, dtype=np.int64)
+        remap[transposed.reshape(-1)] = np.arange(transposed.size)
+
+        idxs = indices[self.channel]
+        indices[self.channel] = np.where(idxs >= 0, remap[idxs], -1)
+
+        return indices
 
     def compute(self, params, observables):
         if self.transpose_idxs == sorted(self.transpose_idxs):

--- a/rabbit/mappings/project.py
+++ b/rabbit/mappings/project.py
@@ -1,85 +1,77 @@
 import tensorflow as tf
 
-from rabbit.mappings.mapping import ChannelMapping
+from rabbit.mappings.mapping import Select
 
 
-class Project(ChannelMapping):
+class Project(Select):
     """
-    A class to project a histogram to lower dimensions.
-    The normalization is done to the integral of all processes or data.
+    A class to project a histogram to lower dimensions, i.e. all axes of the channel
+    that are not kept are summed. The output axes are in the order they are requested.
 
     Parameters
     ----------
-    channel_name : str
+    channel : str
         Name of the channel. Required.
     axes_names : list of str, optional
         Names of the axes to keep. If empty, the histogram will be projected to a single bin.
     """
 
-    def __init__(self, indata, key, channel, *axes_names):
-        super().__init__(indata, key, channel)
-        self.channel = channel
+    def __init__(self, indata, key, channel, *axes_names, **kwargs):
+        channel_axes_names = [a.name for a in indata.channel_info[channel]["axes"]]
 
-        info = indata.channel_info[channel]
-        channel_axes = {a.name: a for a in info["axes"]}
-
-        if len([n for n in axes_names if n not in channel_axes]) > 0:
+        missing = [n for n in axes_names if n not in channel_axes_names]
+        if len(missing):
             raise RuntimeError(
-                f"Axes {[n for n in axes_names if n not in channel_axes]} not found. Available axes are {[channel_axes.keys()]}"
-            )
-        hist_axes = [channel_axes[n] for n in axes_names]
-
-        if len(hist_axes) != len(axes_names):
-            raise ValueError(
-                f"Hist axes {[h.name for h in hist_axes]} != {axes_names} not found"
+                f"Axes {missing} not found. Available axes are {channel_axes_names}"
             )
 
-        channel_axes_names = [axis.name for axis in channel_axes.values()]
+        # a projection is a selection of the channel where all axes that are not kept are summed
+        super().__init__(
+            indata,
+            key,
+            channel,
+            sum_axes=[n for n in channel_axes_names if n not in axes_names],
+            **kwargs,
+        )
 
-        axis_idxs = [channel_axes_names.index(axis) for axis in axes_names]
+        # the axes that are kept are in the order of the channel, the result is transposed
+        #   into the order in which the axes were requested
+        kept_axes_names = [n for n in channel_axes_names if n in axes_names]
+        self.transpose_idxs = [kept_axes_names.index(n) for n in axes_names]
 
-        self.proj_idxs = [i for i in range(len(channel_axes)) if i not in axis_idxs]
+        info = self.channel_info[channel]
+        info["axes"] = [info["axes"][i] for i in self.transpose_idxs]
 
-        post_proj_axes_names = [
-            axis for axis in channel_axes_names if axis in axes_names
-        ]
+    @classmethod
+    def parse_args(cls, indata, channel, *axes_names):
+        """
+        parsing the input arguments into the constructor, it has to be called as
+        -m Project <ch> <axis_0> <axis_1> ...
 
-        self.transpose_idxs = [post_proj_axes_names.index(axis) for axis in axes_names]
+        All axes of the channel that are not listed are summed,
+        listing no axis at all gives the total yield.
+        """
+        key = " ".join([cls.__name__, channel, *axes_names])
 
-        self.has_data = not info.get("masked", False)
+        return cls(indata, key, channel, *axes_names)
 
-        self.channel_info = {
-            channel: {
-                "axes": hist_axes,
-                "flow": info.get("flow", False),
-                "processes": indata.procs,
-            }
-        }
+    def compute(self, params, observables):
+        if self.transpose_idxs == sorted(self.transpose_idxs):
+            # axes are already in the requested order
+            return observables
 
-    def project(self, values):
-        exp = tf.reduce_sum(values, axis=self.proj_idxs)
         perm = self.transpose_idxs[:]
-        if len(exp.shape) > len(self.transpose_idxs):
+        if len(observables.shape) > len(perm):
             # last is process axis
-            perm += list(range(len(self.transpose_idxs), len(exp.shape)))
-        exp = tf.transpose(exp, perm=perm)
-        return exp
+            perm += list(range(len(perm), len(observables.shape)))
 
-    def compute(self, param, observables):
-        return self.project(observables)
+        return tf.transpose(observables, perm=perm)
 
 
 class Normalize(Project):
     """
-    Same as project but also normalize
+    Same as Project but the result is normalized to its integral, summed over all processes
     """
 
     ndf_reduction = 1
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def project(self, values, *args):
-        norm = tf.reduce_sum(values)
-        out = values / norm
-        return super().project(out, *args)
+    normalize = True

--- a/rabbit/param_models/param_model.py
+++ b/rabbit/param_models/param_model.py
@@ -3,6 +3,9 @@ import itertools
 
 import numpy as np
 import tensorflow as tf
+from wums import logging
+
+logger = logging.child_logger(__name__)
 
 
 class ParamModel:
@@ -376,14 +379,26 @@ class Mixture(ParamModel):
 
 class SaturatedProjectModel(ParamModel):
     """
-    For computing the saturated test statistic of a projection.
-    Add one free parameter for each projected bin
+    For computing the saturated test statistic of a mapping that is a selection and a
+    summation of input bins, e.g. a 'Select' or a 'Project' mapping.
+    Add one free parameter for each bin of the mapping output, applied to all bins of the
+    input data contributing to it. Bins that do not enter the mapping are left at one.
+
+    Parameters
+    ----------
+    channel_info : dict
+        Channel info of the mapping, used to name the parameters.
+    indices : dict
+        For each channel of the input data that enters the mapping, the flat index of the
+        output bin each of its bins contributes to, and -1 for bins that are not used,
+        as returned by 'Mapping.output_indices()'.
     """
 
     def __init__(
         self,
         indata,
         channel_info,
+        indices,
         expectSignal=None,
         allowNegativeParam=False,
         **kwargs,
@@ -391,21 +406,40 @@ class SaturatedProjectModel(ParamModel):
         self.indata = indata
         self.channel_info_mapping = channel_info
 
-        self.npoi = int(
-            np.sum(
-                [
-                    np.prod([a.size for a in v["axes"]]) if len(v["axes"]) else 1
-                    for v in channel_info.values()
-                ]
-            )
-        )
+        self.indices = {k: np.asarray(v) for k, v in indices.items()}
+        self.nbins_channel = {k: int(v.max()) + 1 for k, v in self.indices.items()}
+
+        for k, v in self.indices.items():
+            n_empty = self.nbins_channel[k] - len(np.unique(v[v >= 0]))
+            if n_empty:
+                logger.warning(
+                    f"{n_empty} bins of the mapping output in channel '{k}' have no "
+                    "contribution from the input data, their saturated parameters are "
+                    "unconstrained and the number of degrees of freedom is overestimated"
+                )
+
+        self.npoi = int(sum(self.nbins_channel.values()))
         self.npou = 0
 
+        # bins of the input data that are not used by the mapping point to one extra
+        #   parameter that is kept at one
+        self.gather_indices = {
+            k: tf.constant(np.where(v >= 0, v, self.nbins_channel[k]))
+            for k, v in self.indices.items()
+        }
+
         names = []
-        for k, v in self.channel_info_mapping.items():
-            for idxs in itertools.product(*[range(a.size) for a in v["axes"]]):
-                label = "_".join(f"{a.name}{i}" for a, i in zip(v["axes"], idxs))
-                names.append(f"saturated_{k}_{label}".encode())
+        for k, nbins in self.nbins_channel.items():
+            axes = channel_info[k]["axes"]
+            if int(np.prod([a.size for a in axes])) == nbins:
+                labels = [
+                    "_".join(f"{a.name}{i}" for a, i in zip(axes, idxs))
+                    for idxs in itertools.product(*[range(a.size) for a in axes])
+                ]
+            else:
+                # e.g. channels with flow bins, where the axes sizes don't span the output
+                labels = [str(i) for i in range(nbins)]
+            names.extend([f"saturated_{k}_{label}".encode() for label in labels])
 
         self.params = np.array(names)
 
@@ -421,23 +455,21 @@ class SaturatedProjectModel(ParamModel):
         for k, v in self.indata.channel_info.items():
             if v["masked"] and not full:
                 continue
-            shape_input = [a.size for a in v["axes"]]
 
-            irnorm = tf.ones(shape_input, dtype=self.indata.dtype)
-            if k in self.channel_info_mapping.keys():
-                mapping_axes = self.channel_info_mapping[k]["axes"]
-                shape_mapping = [a.size if a in mapping_axes else 1 for a in v["axes"]]
-                n_mapping_params = np.prod([a.size for a in mapping_axes])
-                iparam = param[start : start + n_mapping_params]
-                irnorm *= tf.reshape(iparam, shape_mapping)
-                start += n_mapping_params
+            if k in self.indices.keys():
+                nbins = self.nbins_channel[k]
+                iparam = tf.concat(
+                    [
+                        param[start : start + nbins],
+                        tf.ones([1], dtype=self.indata.dtype),
+                    ],
+                    axis=0,
+                )
+                irnorm = tf.gather(iparam, self.gather_indices[k])
+                start += nbins
+            else:
+                irnorm = tf.ones([v["stop"] - v["start"]], dtype=self.indata.dtype)
 
-            irnorm = tf.reshape(
-                irnorm,
-                [
-                    -1,
-                ],
-            )
             rnorms.append(irnorm)
 
         rnorm = tf.concat(rnorms, axis=0)


### PR DESCRIPTION
## Motivation

The saturated likelihood test (`--computeSaturatedProjectionTests`) was restricted to the `Project` mapping. The saturated model built its per-bin scale factors by reshaping the parameter vector to the channel shape and broadcasting over the summed axes, which can only express "keep whole axes, in the order of the channel". Mappings with a bin selection, a rebinning or a transposition could therefore not be tested.

The concrete use case is the W simultaneous extended ABCD fit in `pt-eta-charge-mt-relIso`: pick the signal region (`mt` bin 2, `relIso` bin 0), project it to `pt`, and test the goodness of fit of that spectrum:

```
-m Select ch0 None 'eta:sum,charge:sum,mt:2,relIso:0' --computeSaturatedProjectionTests
```

## Changes

**1. Implement the `Project` mapping through the `Select` mapping** (behaviour preserving)

A projection is a selection of a channel where all axes that are not kept are summed, which `Select` already supports through its `axis:sum` selections. `Project` now derives from `Select` and only adds the transposition into the requested axis order, and `Normalize` is expressed through the `normalize` argument of `Term.select` instead of implementing its own projection. `Project` therefore also supports process selections, bin selections and rebinning when constructed programmatically. The command line interface and the keys under which results are stored are unchanged.

Also drops the unused `Term.selection_idxs` and a no-op loop in `parse_axis_selection` that re-used a leaked loop variable.

**2. Support the saturated likelihood test for any selection mapping**

Mappings that are a selection and a summation of input bins now report, through a new `Mapping.output_indices()`, the flat index of the output bin each input bin contributes to (`-1` for bins that are not used). The saturated model gathers one free parameter per output bin onto the bins contributing to it and leaves all other bins at one, so any `Select` or `Project` mapping can be tested. Mappings that are not a plain sum of input bins, such as `Normalize` or a selection of processes, return `None` and are skipped, as are mappings without data.

Fixed along the way:
- projecting to a single bin (`-m Project <ch>`) raised, because `np.prod([])` returns a float
- the number of bins per channel was computed as `prod(axis.size)`, which is wrong for channels with flow bins
- for projections with transposed axes the saturated parameters were named in the order of the output but applied in the order of the channel, so the labels did not match the bins. The test statistic was unaffected, being invariant under a permutation of free parameters.

Parameters of the original model that only affect bins made free by the saturated model are degenerate with it, so the covariance of the saturated fit can be singular. This is now a warning instead of an error; the test statistic itself does not need the hessian.

## Validation

- The index map reproduces `compute_flat` exactly in 15 configurations: bin selections, strided slices, partial rebinning where half of the input bins are dropped, fully summed channels and transposed projections.
- On the test tensor all pre-existing saturated tests are unchanged to 10 decimals: `Project ch0 x` 4.9745507501, `Project ch1 b` 1.3181413045, `Project ch1 b a` 47.3605767679. `Select ch1` now gets one as well, giving the same 47.3605767679 over the same 50 bins.
- `Project` and `Normalize` outputs are identical to the previous implementation in 22 configurations (axes, flow, masked channels, per-process paths, result keys, `ndf_reduction`). The exception is `Normalize` at the 1e-17 level, where the division now happens once on the summed result instead of per bin before summing.
- On a 5D `pt-eta-charge-mt-relIso` toy the signal-region projection gives ndof 6, 2*deltaNLL 1.81, p = 93.6%, agreeing with the independent linear chi2 p-value. Injecting a 12% tilt into the signal-region pt spectrum of the data drives it to 2*deltaNLL 272 (p = 0%) while an untouched sideband stays at 3.12 (p = 79%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTEH6bvho5ziaobKWG153D
