### PR TITLE
Snapshot the fit parameters, so an interrupted fit is not a lost fit

### DIFF
--- a/bin/rabbit_fit.py
+++ b/bin/rabbit_fit.py
@@ -873,6 +873,17 @@ def main():
     )
     blinded_fits = [f == 0 or (f > 0 and args.toysDataMode == "observed") for f in fits]
 
+    # Default snapshot destination, next to the fit output it belongs to. Only
+    # when periodic snapshots were asked for: the interrupt/failure/convergence
+    # ones are cheap but still a file appearing where the user did not ask for
+    # one, so those follow --snapshotFile only.
+    if args.snapshotFile is None and args.snapshotInterval > 0:
+        stem = _os.path.splitext(args.outname)[0]
+        if args.postfix:
+            stem = f"{stem}_{args.postfix}"
+        args.snapshotFile = _os.path.join(args.outpath, f"{stem}_snapshot.hdf5")
+        _os.makedirs(args.outpath, exist_ok=True)
+
     indata = inputdata.FitInputData(args.filename, args.pseudoData)
 
     model_specs = args.paramModel or [["Mu"]]

--- a/rabbit/callbacks.py
+++ b/rabbit/callbacks.py
@@ -23,9 +23,14 @@ logger = logging.child_logger(__name__)
 
 
 class FitterCallback:
-    def __init__(self, xv, early_stopping=-1):
+    def __init__(self, xv, early_stopping=-1, snapshotter=None):
         self.iiter = 0
         self.xval = xv
+        # Optional rabbit.snapshot.Snapshotter. The callback is the only place
+        # that sees the accepted iterate every iteration, which is exactly what
+        # a snapshot wants: trial points the trust region goes on to reject are
+        # not states the fit was ever in.
+        self.snapshotter = snapshotter
 
         self.loss_history = []
         self.time_history = []
@@ -66,6 +71,14 @@ class FitterCallback:
 
         self.xval = intermediate_result.x
         self.iiter += 1
+
+        # After the update, so the snapshot and the loss recorded with it are
+        # the same iterate. Placed after the early-stopping check too: that
+        # path raises, and fit() snapshots on the way out.
+        if self.snapshotter is not None:
+            self.snapshotter.maybe_save(
+                self.xval, elapsed, iteration=self.iiter, loss=float(loss)
+            )
 
 
 # Relative loss improvement below which a restart counts as having bought

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -26,6 +26,7 @@ from rabbit.impacts import (
     nonprofiled_impacts,
     traditional_impacts,
 )
+from rabbit.snapshot import Snapshotter, snapshot_on_signal
 from rabbit.tfhelpers import edmval_cov
 
 logger = logging.child_logger(__name__)
@@ -95,6 +96,11 @@ class Fitter:
         self.hvp_method = getattr(options, "hvpMethod", "revrev")
         # Optional parameter preconditioning (see rabbit/preconditioner.py).
         # getattr so callers that build options objects by hand keep working.
+        # Parameter snapshots (see rabbit/snapshot.py). Everything the fit has
+        # learned lives in memory until the output is written at the very end,
+        # so without these an interrupted fit leaves nothing at all.
+        self.snapshot_file = getattr(options, "snapshotFile", None)
+        self.snapshot_interval = float(getattr(options, "snapshotInterval", 0.0) or 0.0)
         self.precondition = getattr(options, "precondition", False)
         self.precondition_params = getattr(options, "preconditionParams", None)
         self.precondition_from = getattr(options, "preconditionFrom", "hessian")
@@ -2427,80 +2433,106 @@ class Fitter:
         callback = None
         prev_loss = None
         attempt = 0
-        while True:
-            cb = FitterCallback(xval, self.earlyStopping)
-            try:
-                res = scipy.optimize.minimize(
-                    scipy_loss,
-                    xval,
-                    method=self.minimizer_method,
-                    jac=True,
-                    tol=0.0,
-                    callback=cb,
-                    options=sci_opts,
-                    **info_minimize,
-                )
-            except Exception as ex:
-                # minimizer could have called the loss or hessp functions with "random" values, so restore the
-                # state from the end of the last iteration before the exception
-                xval = cb.xval
-                self.minimizer_result = None
+
+        # to_physical is the whole reason this is built here rather than in the
+        # callback: under preconditioning the minimiser's iterate is in internal
+        # coordinates, and a snapshot of those would load without complaint and
+        # be wrong. pc_cell is read at save time, not captured, so a rebuilt
+        # transform is picked up.
+        snapshotter = Snapshotter(
+            self.snapshot_file,
+            self.parms,
+            to_physical=lambda v: pc_cell[0].to_physical(v),
+            interval_hours=self.snapshot_interval,
+        )
+        snapshotter.update(xval)
+
+        with snapshot_on_signal(snapshotter):
+            while True:
+                cb = FitterCallback(xval, self.earlyStopping, snapshotter=snapshotter)
+                try:
+                    res = scipy.optimize.minimize(
+                        scipy_loss,
+                        xval,
+                        method=self.minimizer_method,
+                        jac=True,
+                        tol=0.0,
+                        callback=cb,
+                        options=sci_opts,
+                        **info_minimize,
+                    )
+                except Exception as ex:
+                    # minimizer could have called the loss or hessp functions with "random" values, so restore the
+                    # state from the end of the last iteration before the exception
+                    xval = cb.xval
+                    self.minimizer_result = None
+                    if not cb.stopped_early:
+                        # a real failure, not a stall: surface it rather than
+                        # letting a broken callback look like a converged fit
+                        logger.warning(f"Minimizer raised: {ex}")
+                        # the expensive case: a failure here used to discard the
+                        # whole fit, however close to the minimum it had got
+                        snapshotter.save(
+                            cb.xval, "minimizer-failed", error=str(ex)[:200]
+                        )
+                    logger.debug(ex)
+                else:
+                    xval = res["x"]
+                    self.minimizer_result = res
+                    logger.debug(res)
+
+                callback = merge_callbacks(callback, cb)
+                last_loss = cb.loss_history[-1] if cb.loss_history else None
+
                 if not cb.stopped_early:
-                    # a real failure, not a stall: surface it rather than
-                    # letting a broken callback look like a converged fit
-                    logger.warning(f"Minimizer raised: {ex}")
-                logger.debug(ex)
-            else:
-                xval = res["x"]
-                self.minimizer_result = res
-                logger.debug(res)
-
-            callback = merge_callbacks(callback, cb)
-            last_loss = cb.loss_history[-1] if cb.loss_history else None
-
-            if not cb.stopped_early:
-                break
-            # The only reason to stop restarting is that the last restart
-            # bought nothing: a round can never end above where it started
-            # (the trust region accepts improving steps only), so "not below
-            # the previous round" means the descent is genuinely exhausted.
-            if (
-                prev_loss is not None
-                and last_loss is not None
-                and last_loss
-                >= prev_loss - RESTART_MIN_IMPROVEMENT * max(1.0, abs(prev_loss))
-            ):
+                    break
+                # The only reason to stop restarting is that the last restart
+                # bought nothing: a round can never end above where it started
+                # (the trust region accepts improving steps only), so "not below
+                # the previous round" means the descent is genuinely exhausted.
+                if (
+                    prev_loss is not None
+                    and last_loss is not None
+                    and last_loss
+                    >= prev_loss - RESTART_MIN_IMPROVEMENT * max(1.0, abs(prev_loss))
+                ):
+                    logger.info(
+                        f"Restart did not reduce the loss further ({prev_loss} -> "
+                        f"{last_loss}); stopping after {attempt} restart(s)."
+                    )
+                    break
+                if 0 <= self.max_restarts <= attempt:
+                    logger.warning(
+                        f"Minimizer still stalling at loss {last_loss} after "
+                        f"{self.max_restarts} restart(s) and the loss was still "
+                        "coming down; raise --maxRestarts to let it continue."
+                    )
+                    break
+                attempt += 1
                 logger.info(
-                    f"Restart did not reduce the loss further ({prev_loss} -> "
-                    f"{last_loss}); stopping after {attempt} restart(s)."
+                    f"Minimizer stalled at loss {last_loss}; restarting "
+                    f"(#{attempt}) to reset the trust radius."
                 )
-                break
-            if 0 <= self.max_restarts <= attempt:
-                logger.warning(
-                    f"Minimizer still stalling at loss {last_loss} after "
-                    f"{self.max_restarts} restart(s) and the loss was still "
-                    "coming down; raise --maxRestarts to let it continue."
-                )
-                break
-            attempt += 1
-            logger.info(
-                f"Minimizer stalled at loss {last_loss}; restarting "
-                f"(#{attempt}) to reset the trust radius."
-            )
-            prev_loss = last_loss
+                prev_loss = last_loss
 
-            # Rebuild the transform at the point we are restarting from. The
-            # one built at the start whitens the Hessian *there*; by the time
-            # the fit has stalled somewhere else that Hessian has changed and
-            # the transform no longer conditions anything. Refreshing costs one
-            # Hessian evaluation and is a no-op when preconditioning is off.
-            self.x.assign(pc_cell[0].to_physical(xval))
-            pc_cell[0] = self._build_preconditioner()
-            xval = pc_cell[0].from_physical(self.x.numpy())
+                # Rebuild the transform at the point we are restarting from. The
+                # one built at the start whitens the Hessian *there*; by the time
+                # the fit has stalled somewhere else that Hessian has changed and
+                # the transform no longer conditions anything. Refreshing costs one
+                # Hessian evaluation and is a no-op when preconditioning is off.
+                self.x.assign(pc_cell[0].to_physical(xval))
+                pc_cell[0] = self._build_preconditioner()
+                xval = pc_cell[0].from_physical(self.x.numpy())
 
         # xval (and callback.xval) are internal coordinates; everything outside
         # fit() expects physical parameters.
         self.x.assign(pc_cell[0].to_physical(xval))
+
+        # The minimum itself. Writing it costs nothing next to the fit and
+        # covers the stretch that is otherwise unprotected: everything between
+        # here and the output file being closed, which on a large model means
+        # the Hessian, the impacts and the postfit histograms.
+        snapshotter.save(xval, "converged")
 
         return callback
 

--- a/rabbit/parsing.py
+++ b/rabbit/parsing.py
@@ -293,6 +293,29 @@ def common_parser():
         "falls back to no preconditioning.",
     )
     parser.add_argument(
+        "--snapshotFile",
+        default=None,
+        type=str,
+        help="Write parameter snapshots to this file. A snapshot holds the "
+        "parameter values and names -- enough to resume with --externalPostfit "
+        "<file>, either to carry on minimizing or, with --noFit, to run only "
+        "the postfit step at that point. One is written when the minimizer is "
+        "interrupted (SIGINT/SIGTERM), when it fails, and when it converges, "
+        "so a long fit killed at any stage still leaves its parameters behind. "
+        "Snapshots are written atomically, so an interrupted write cannot "
+        "destroy the previous one. Default: <outdir>/<outname stem>_snapshot.hdf5 "
+        "when --snapshotInterval is set, otherwise off.",
+    )
+    parser.add_argument(
+        "--snapshotInterval",
+        default=0.0,
+        type=float,
+        help="Also snapshot every this many hours of fitting (0 disables the "
+        "periodic ones; the interrupt, failure and convergence snapshots do not "
+        "depend on it). Costs one small file write per interval. Worth setting "
+        "on any fit long enough that losing it would hurt.",
+    )
+    parser.add_argument(
         "--hvpMethod",
         default="revrev",
         type=str,

--- a/rabbit/snapshot.py
+++ b/rabbit/snapshot.py
@@ -1,0 +1,200 @@
+"""Parameter snapshots, so an interrupted fit is not a lost fit.
+
+A long fit is fragile in a way its length makes expensive. Everything the
+minimiser has learned lives in one in-memory vector until the very end: the
+output file is written only after ``minimize()`` returns, so a fit that is
+killed, hits a wall clock limit, or dies writing its output leaves nothing at
+all behind, however close to the minimum it had got.
+
+A snapshot is that vector on disk. It is deliberately the smallest thing that
+:meth:`rabbit.fitter.Fitter.load_fitresult` will accept -- the parameter values
+and their names -- so a fit can be resumed from one with
+
+    rabbit_fit.py input.hdf5 -o out/ --externalPostfit snapshot.hdf5
+
+either to carry on minimising or, with ``--noFit``, to run just the postfit
+step at the snapshot point. No covariance is stored: it does not exist until
+the Hessian is computed, and ``load_fitresult`` treats it as optional.
+
+Two things here are not incidental.
+
+*The write is atomic.* Snapshots exist for the case where the process dies at a
+moment it did not choose, and that includes while a snapshot is being written.
+Writing in place would then leave a truncated file where a good one used to be,
+turning the safety net into the thing that destroys the result. Each snapshot
+is written to a temporary file in the same directory and moved into place with
+``os.replace``, which is atomic on POSIX, so a reader sees either the previous
+snapshot or the new one.
+
+*The values are physical.* Under preconditioning the minimiser works in
+internal coordinates and the callback's iterate is in those coordinates; the
+transform has to be undone before writing. A snapshot of internal coordinates
+would load without complaint and be silently wrong.
+
+Nothing here imports the fitter, and so nothing here imports TensorFlow --
+worth keeping that way. It makes the module usable from a signal handler and
+from a plain subprocess, where pulling in TensorFlow costs minutes.
+"""
+
+import contextlib
+import os
+import signal
+
+import h5py
+import numpy as np
+from wums import logging
+
+logger = logging.child_logger(__name__)
+
+
+def write_snapshot(filename, parms, x, meta=None):
+    """Write parameter values and names to ``filename``, atomically.
+
+    ``parms`` and ``x`` must be aligned. ``meta`` is an optional dict of
+    scalars stored as HDF5 attributes; it is provenance only and nothing reads
+    it back, so a snapshot stays loadable if its contents ever change.
+    """
+    x = np.asarray(x)
+    parms = np.asarray(parms).astype(str)
+    if x.shape != parms.shape:
+        raise ValueError(
+            f"snapshot: {x.size} parameter values against {parms.size} names"
+        )
+
+    directory = os.path.dirname(os.path.abspath(filename))
+    # NB same directory as the target: os.replace is only atomic within a
+    # filesystem, and /tmp is routinely a different one
+    tmp = os.path.join(directory, f".{os.path.basename(filename)}.tmp")
+
+    with h5py.File(tmp, "w") as f:
+        f.create_dataset("x", data=x)
+        f.create_dataset(
+            "parms", data=parms.astype(object), dtype=h5py.special_dtype(vlen=str)
+        )
+        for key, value in (meta or {}).items():
+            f.attrs[key] = value
+    os.replace(tmp, filename)
+
+
+class Snapshotter:
+    """Decides when to snapshot and where to put it.
+
+    Holds the mapping back to physical coordinates, so callers never have to
+    remember to undo the preconditioner themselves.
+    """
+
+    def __init__(self, filename, parms, to_physical=None, interval_hours=0.0):
+        self.filename = filename
+        self.parms = parms
+        self.to_physical = to_physical if to_physical is not None else (lambda v: v)
+        # negative or zero disables the periodic snapshots; an explicit save
+        # (a signal, a failing minimiser) is always honoured
+        self.interval = float(interval_hours) * 3600.0
+        self.last_write = None
+        self.count = 0
+        # most recent accepted iterate, already in physical coordinates
+        self.latest = None
+
+    def update(self, xval):
+        """Record ``xval`` (internal coordinates) as the latest good point.
+
+        Converting on the way in rather than on the way out is what makes a
+        snapshot safe during a preconditioner rebuild: for the minutes that
+        takes, the stored transform no longer matches the stored iterate, and
+        anything converting lazily would write a vector mapped by the wrong
+        one.
+        """
+        self.latest = np.asarray(self.to_physical(np.asarray(xval)))
+
+    def _write(self, reason, **meta):
+        """Never raises: the snapshot is insurance, not the product, so a
+        failure here must not take down a fit that is otherwise fine."""
+        if self.filename is None or self.latest is None:
+            return False
+        try:
+            write_snapshot(
+                self.filename, self.parms, self.latest, meta={"reason": reason, **meta}
+            )
+        except Exception as ex:  # pragma: no cover - defensive
+            logger.warning(f"Could not write snapshot to {self.filename}: {ex}")
+            return False
+        self.count += 1
+        logger.info(
+            f"Wrote parameter snapshot ({reason}) to {self.filename}; resume with "
+            f"--externalPostfit {self.filename}"
+        )
+        return True
+
+    def save(self, xval, reason, **meta):
+        """Snapshot ``xval`` unconditionally, whatever the interval says."""
+        self.update(xval)
+        return self._write(reason, **meta)
+
+    def save_latest(self, reason, **meta):
+        """Snapshot the last point handed to :meth:`update`.
+
+        This is the signal path: it must not need an iterate passed in, since
+        a signal can arrive at any point in an iteration -- and with iterations
+        running to hours on a large fit, waiting for the next one is not a
+        usable answer.
+        """
+        return self._write(reason, **meta)
+
+    def maybe_save(self, xval, elapsed, reason="periodic", **meta):
+        """Record the point, and snapshot it if the interval has passed.
+
+        The first call always writes. That is deliberate: it proves the path is
+        writable at iteration 1 rather than at hour 100, which is when it
+        matters and far too late to learn otherwise.
+        """
+        self.update(xval)
+        if self.filename is None or self.interval <= 0:
+            return False
+        if self.last_write is not None and elapsed - self.last_write < self.interval:
+            return False
+        self.last_write = elapsed
+        return self._write(reason, elapsed=elapsed, **meta)
+
+
+@contextlib.contextmanager
+def snapshot_on_signal(snapshotter):
+    """Write a snapshot when the job is asked to stop, then get out of the way.
+
+    SIGTERM is how a batch scheduler announces a wall clock limit and how
+    ``kill`` reaches a fit someone has decided to stop; SIGINT is Ctrl-C.
+    Both otherwise destroy every parameter value the fit has found.
+
+    The snapshot is written from inside the handler rather than by asking
+    the minimiser to stop at the next iteration. On a large model a single
+    iteration can run for hours, and a scheduler that has sent SIGTERM will
+    follow it with SIGKILL long before then -- so a cooperative stop would
+    arrive too late to be the safety net this is for.
+
+    The previous handler is then restored and the signal re-raised, so the
+    process still dies the way the sender intended and with the right exit
+    status. Nothing about the fit's own control flow changes.
+    """
+    if snapshotter.filename is None:
+        yield
+        return
+
+    previous = {}
+
+    def handle(signum, frame):
+        snapshotter.save_latest(f"signal-{signal.Signals(signum).name}")
+        signal.signal(signum, previous.get(signum, signal.SIG_DFL))
+        os.kill(os.getpid(), signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            previous[sig] = signal.signal(sig, handle)
+        except ValueError:
+            # signal handlers can only be installed from the main thread;
+            # off the main thread the periodic and failure snapshots still
+            # work, so carry on rather than refusing to fit
+            logger.debug(f"Could not install a {sig!r} snapshot handler")
+    try:
+        yield
+    finally:
+        for sig, prev in previous.items():
+            signal.signal(sig, prev)

--- a/rabbit/snapshot.py
+++ b/rabbit/snapshot.py
@@ -39,6 +39,7 @@ from a plain subprocess, where pulling in TensorFlow costs minutes.
 import contextlib
 import os
 import signal
+import threading
 
 import h5py
 import numpy as np
@@ -164,37 +165,102 @@ def snapshot_on_signal(snapshotter):
     ``kill`` reaches a fit someone has decided to stop; SIGINT is Ctrl-C.
     Both otherwise destroy every parameter value the fit has found.
 
-    The snapshot is written from inside the handler rather than by asking
-    the minimiser to stop at the next iteration. On a large model a single
-    iteration can run for hours, and a scheduler that has sent SIGTERM will
-    follow it with SIGKILL long before then -- so a cooperative stop would
-    arrive too late to be the safety net this is for.
+    Doing the write in the Python signal handler does not work here, which was
+    learned the expensive way: a preempted 22-hour fit wrote 33 periodic
+    snapshots and zero signal ones. Python runs signal handlers only in the
+    main thread, between bytecodes, and this fit spends its time inside single
+    TensorFlow calls that run for minutes -- one iteration took 910 s. SIGTERM
+    arrived, the interpreter never regained control to dispatch it, and SIGKILL
+    followed. A cooperative "stop at the next iteration" fails for the same
+    reason, only worse.
 
-    The previous handler is then restored and the signal re-raised, so the
-    process still dies the way the sender intended and with the right exit
-    status. Nothing about the fit's own control flow changes.
+    So the C-level handler writes the signal number to a pipe (that is all
+    ``set_wakeup_fd`` does, and it happens immediately and without the GIL),
+    and a daemon thread blocked on the read end does the snapshot. TensorFlow
+    releases the GIL for the duration of a long op, so that thread runs while
+    the main thread is still down in C++. The Python-level handler installed
+    alongside is deliberately a no-op: its only job is to make the signal
+    "handled" so that set_wakeup_fd reports it.
+
+    The thread then exits the process itself with 128+signum, the encoding a
+    shell reports for a signal death. It cannot re-raise the signal properly:
+    that needs signal.signal() to restore the default disposition, and Python
+    only allows that from the main thread -- the very thread that is stuck.
     """
     if snapshotter.filename is None:
         yield
         return
 
+    read_fd, write_fd = os.pipe()
+    # set_wakeup_fd requires a non-blocking write end -- it must never stall
+    # inside the C handler; the reader blocks, which is what we want.
+    os.set_blocking(write_fd, False)
+    os.set_blocking(read_fd, True)
+
     previous = {}
+    stopping = threading.Event()
 
-    def handle(signum, frame):
-        snapshotter.save_latest(f"signal-{signal.Signals(signum).name}")
-        signal.signal(signum, previous.get(signum, signal.SIG_DFL))
-        os.kill(os.getpid(), signum)
+    def _worker():
+        while True:
+            try:
+                data = os.read(read_fd, 1)
+            except OSError:
+                return
+            if not data or stopping.is_set():
+                return  # the sentinel written on clean exit
+            signum = data[0]
+            snapshotter.save_latest(f"signal-{signal.Signals(signum).name}")
+            # Terminate from here rather than re-raising. Restoring SIG_DFL
+            # first would be the tidy way, but signal.signal() only works on
+            # the main thread -- and the main thread is the one stuck in C,
+            # which is why this thread exists at all. os._exit is immediate and
+            # skips interpreter shutdown, which matters: the snapshot is
+            # already on disk and a scheduler that sent SIGTERM is counting
+            # down to SIGKILL. 128+signum is the conventional encoding a shell
+            # reports for a signal death.
+            os._exit(128 + signum)
 
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        try:
-            previous[sig] = signal.signal(sig, handle)
-        except ValueError:
-            # signal handlers can only be installed from the main thread;
-            # off the main thread the periodic and failure snapshots still
-            # work, so carry on rather than refusing to fit
-            logger.debug(f"Could not install a {sig!r} snapshot handler")
+    thread = None
+    prev_wakeup = None
+
+    def _noop(signum, frame):
+        """Never does the work; see the class docstring. Present only so the
+        signal counts as handled and set_wakeup_fd fires for it."""
+
+    try:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            previous[sig] = signal.signal(sig, _noop)
+        prev_wakeup = signal.set_wakeup_fd(write_fd)
+    except ValueError:
+        # only the main thread may install handlers or a wakeup fd; off it the
+        # periodic and failure snapshots still work, so carry on rather than
+        # refusing to fit
+        logger.debug("Could not arm signal snapshots (not the main thread)")
+        for sig, prev in previous.items():
+            signal.signal(sig, prev)
+        previous.clear()
+    else:
+        thread = threading.Thread(
+            target=_worker, name="snapshot-on-signal", daemon=True
+        )
+        thread.start()
+
     try:
         yield
     finally:
+        stopping.set()
+        if prev_wakeup is not None:
+            signal.set_wakeup_fd(prev_wakeup)
         for sig, prev in previous.items():
             signal.signal(sig, prev)
+        if thread is not None:
+            try:
+                os.write(write_fd, b"\x00")  # wake the reader so it can exit
+            except OSError:
+                pass
+            thread.join(timeout=5.0)
+        for fd in (write_fd, read_fd):
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,175 @@
+"""Snapshots: an interrupted fit must not be a lost fit.
+
+The contract is narrow and worth stating: a snapshot has to be loadable by
+Fitter.load_fitresult, which is what --externalPostfit calls. Anything that
+writes a file load_fitresult will not read is useless however well formed.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from rabbit import fitter, inputdata
+from rabbit.param_models.helpers import load_model
+from rabbit.snapshot import Snapshotter, write_snapshot
+
+from .test_sparse_fit import make_options, make_test_tensor
+
+
+def test_snapshot_round_trips_through_load_fitresult():
+    """The point of the whole feature: a snapshot resumes a fit.
+
+    Loading is done by the same call --externalPostfit uses, so this fails if
+    the file layout ever drifts from what load_fitresult accepts.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        filename = make_test_tensor(tmp)
+        indata_obj = inputdata.FitInputData(filename)
+        param_model = load_model("Mu", indata_obj)
+        f = fitter.Fitter(indata_obj, param_model, make_options())
+        f.set_nobs(indata_obj.data_obs)
+        f.minimize()
+        fitted = f.x.numpy().copy()
+
+        snap = os.path.join(tmp, "snapshot.hdf5")
+        write_snapshot(snap, f.parms, fitted)
+
+        # a fresh fitter, deliberately somewhere else
+        g = fitter.Fitter(indata_obj, load_model("Mu", indata_obj), make_options())
+        g.set_nobs(indata_obj.data_obs)
+        g.x.assign(np.zeros_like(fitted))
+        g.load_fitresult(snap, None, profile=False)
+        assert np.allclose(g.x.numpy(), fitted, rtol=0, atol=0)
+
+
+def test_snapshot_undoes_the_preconditioner():
+    """Internal coordinates would load without complaint and be wrong."""
+    parms = np.array(["a", "b"])
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        s = Snapshotter(path, parms, to_physical=lambda v: 10.0 * v)
+        s.save(np.array([1.0, 2.0]), "test")
+        with h5py.File(path, "r") as h:
+            assert np.allclose(h["x"][...], [10.0, 20.0])
+            assert list(h["parms"][...].astype(str)) == ["a", "b"]
+
+
+def test_conversion_uses_the_transform_current_at_the_time():
+    """A rebuilt preconditioner must not retroactively remap an old iterate.
+
+    The rebuild takes minutes on a real model, and a signal arriving inside
+    that window would otherwise write a vector mapped by the wrong transform.
+    """
+    scale = [2.0]
+    parms = np.array(["a"])
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        s = Snapshotter(path, parms, to_physical=lambda v: scale[0] * v)
+        s.update(np.array([3.0]))  # recorded as 6.0
+        scale[0] = 1000.0  # transform rebuilt
+        s.save_latest("signal")
+        with h5py.File(path, "r") as h:
+            assert np.allclose(h["x"][...], [6.0])
+
+
+def test_interrupted_write_cannot_destroy_the_previous_snapshot():
+    """The failure mode the atomic write exists for."""
+    parms = np.array(["a"])
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        write_snapshot(path, parms, np.array([1.0]))
+
+        class Boom(Exception):
+            pass
+
+        def explode(*a, **k):
+            raise Boom
+
+        s = Snapshotter(path, parms)
+        s.latest = np.array([2.0])
+        import rabbit.snapshot as mod
+
+        original, mod.write_snapshot = mod.write_snapshot, explode
+        try:
+            assert s._write("test") is False  # swallowed, not raised
+        finally:
+            mod.write_snapshot = original
+        with h5py.File(path, "r") as h:
+            assert np.allclose(h["x"][...], [1.0]), "old snapshot survived"
+        assert [n for n in os.listdir(tmp) if n.startswith(".")] == []
+
+
+def test_periodic_snapshots_respect_the_interval():
+    parms = np.array(["a"])
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        s = Snapshotter(path, parms, interval_hours=1.0)
+        x = np.array([1.0])
+        assert s.maybe_save(x, 0.0) is True  # first write proves the path works
+        assert s.maybe_save(x, 1800.0) is False  # half an hour later
+        assert s.maybe_save(x, 3700.0) is True  # past the hour
+        assert s.count == 2
+
+
+def test_periodic_off_by_default_but_still_tracks_the_point():
+    """interval 0 must not write, yet an interrupt still has a point to save."""
+    parms = np.array(["a"])
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        s = Snapshotter(path, parms, interval_hours=0.0)
+        assert s.maybe_save(np.array([7.0]), 1e9) is False
+        assert not os.path.exists(path)
+        assert s.save_latest("signal") is True
+        with h5py.File(path, "r") as h:
+            assert np.allclose(h["x"][...], [7.0])
+
+
+def test_no_file_configured_is_a_silent_no_op():
+    s = Snapshotter(None, np.array(["a"]))
+    assert s.maybe_save(np.array([1.0]), 1e9) is False
+    assert s.save(np.array([1.0]), "x") is False
+
+
+def test_mismatched_lengths_are_rejected():
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(ValueError, match="against"):
+            write_snapshot(
+                os.path.join(tmp, "s.hdf5"), np.array(["a", "b"]), np.array([1.0])
+            )
+
+
+def test_sigterm_writes_a_snapshot_before_the_process_dies():
+    """SIGTERM is how a scheduler announces a wall clock limit.
+
+    Run in a subprocess: the handler re-raises the signal, so the process is
+    meant to actually die, and the test is that the file is on disk afterwards.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        # rabbit.snapshot deliberately does not import the fitter, so this
+        # subprocess starts without TensorFlow and the test runs in seconds
+        script = f"""
+import os, signal, time, numpy as np
+from rabbit.snapshot import Snapshotter, snapshot_on_signal
+s = Snapshotter({path!r}, np.array(["a", "b"]))
+s.update(np.array([1.5, -2.5]))
+with snapshot_on_signal(s):
+    os.kill(os.getpid(), signal.SIGTERM)
+    time.sleep(30)
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, timeout=60
+        )
+        assert proc.returncode == -signal.SIGTERM, (
+            f"expected death by SIGTERM, got {proc.returncode}: "
+            f"{proc.stderr.decode()[-500:]}"
+        )
+        with h5py.File(path, "r") as h:
+            assert np.allclose(h["x"][...], [1.5, -2.5])
+            assert h.attrs["reason"] == "signal-SIGTERM"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -10,6 +10,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 
 import h5py
 import numpy as np
@@ -147,29 +148,106 @@ def test_mismatched_lengths_are_rejected():
 def test_sigterm_writes_a_snapshot_before_the_process_dies():
     """SIGTERM is how a scheduler announces a wall clock limit.
 
-    Run in a subprocess: the handler re-raises the signal, so the process is
-    meant to actually die, and the test is that the file is on disk afterwards.
+    The main thread is deliberately blocked inside a long numpy matmul, not a
+    sleep. That is the case this mechanism exists for and the one an earlier
+    sleep-based version of this test failed to cover: a sleep is interruptible,
+    so Python dispatches the handler immediately and the test passes whether or
+    not the design works. A matmul holds the interpreter down in C for its
+    whole duration -- exactly like the TensorFlow calls a real fit spends
+    minutes inside -- and the snapshot has to be written anyway.
+
+    The assertion is therefore on *latency*: the process must die promptly
+    after the signal, not when the matmul happens to finish.
     """
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, "s.hdf5")
-        # rabbit.snapshot deliberately does not import the fitter, so this
-        # subprocess starts without TensorFlow and the test runs in seconds
+        # np.sort, not a matmul: sorting is single-threaded and its cost is
+        # predictable, whereas BLAS picks thread counts by matrix size, so a
+        # small calibration matmul does not extrapolate (a run sized for 25 s
+        # finished in 0.58 s on a many-core box). Both hold the interpreter in
+        # C for the whole call, which is the property under test.
         script = f"""
-import os, signal, time, numpy as np
+import os, signal, threading, time
+import numpy as np
 from rabbit.snapshot import Snapshotter, snapshot_on_signal
+
+rng = np.random.default_rng(0)
+big = rng.random(300_000_000)          # ~2.4 GB, sorts in tens of seconds
+
 s = Snapshotter({path!r}, np.array(["a", "b"]))
 s.update(np.array([1.5, -2.5]))
-with snapshot_on_signal(s):
+
+def fire():
+    time.sleep(2.0)
     os.kill(os.getpid(), signal.SIGTERM)
-    time.sleep(30)
+
+threading.Thread(target=fire, daemon=True).start()
+with snapshot_on_signal(s):
+    start = time.perf_counter()
+    big.sort()      # main thread is now in C, holding no Python bytecode
+    print("BLOCKING_CALL_FINISHED", time.perf_counter() - start, flush=True)
+    time.sleep(60)
 """
+        t0 = time.perf_counter()
         proc = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, timeout=60
+            [sys.executable, "-c", script], capture_output=True, timeout=300
         )
-        assert proc.returncode == -signal.SIGTERM, (
-            f"expected death by SIGTERM, got {proc.returncode}: "
-            f"{proc.stderr.decode()[-500:]}"
+        elapsed = time.perf_counter() - t0
+
+        assert proc.returncode == 128 + int(signal.SIGTERM), (
+            f"expected exit 128+SIGTERM, got {proc.returncode}: "
+            f"{proc.stderr.decode()[-600:]}"
         )
         with h5py.File(path, "r") as h:
             assert np.allclose(h["x"][...], [1.5, -2.5])
             assert h.attrs["reason"] == "signal-SIGTERM"
+        # the sort runs for tens of seconds; dying inside 15 s means the
+        # snapshot happened while the main thread was still in C, which is the
+        # whole point. The guard above catches the case where it did not.
+        assert b"BLOCKING_CALL_FINISHED" not in proc.stdout, (
+            "the blocking call finished before the signal was handled; this "
+            "run did not exercise a blocked main thread, so it proves nothing"
+        )
+        assert elapsed < 15.0, f"snapshot-on-signal took {elapsed:.1f}s"
+
+
+def test_sigint_also_snapshots():
+    """Ctrl-C, with the main thread responsive -- the easy case still works."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "s.hdf5")
+        script = f"""
+import os, signal, time
+import numpy as np
+from rabbit.snapshot import Snapshotter, snapshot_on_signal
+s = Snapshotter({path!r}, np.array(["a"]))
+s.update(np.array([9.0]))
+with snapshot_on_signal(s):
+    os.kill(os.getpid(), signal.SIGINT)
+    time.sleep(30)
+"""
+        proc = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, timeout=120
+        )
+        assert proc.returncode == 128 + int(signal.SIGINT), proc.stderr.decode()[-400:]
+        with h5py.File(path, "r") as h:
+            assert np.allclose(h["x"][...], [9.0])
+            assert h.attrs["reason"] == "signal-SIGINT"
+
+
+def test_handlers_and_wakeup_fd_are_restored_on_exit():
+    """The context manager must leave the process as it found it, or a second
+    fit in the same process inherits a dangling pipe."""
+    import rabbit.snapshot as mod
+
+    before_term = signal.getsignal(signal.SIGTERM)
+    before_int = signal.getsignal(signal.SIGINT)
+    with tempfile.TemporaryDirectory() as tmp:
+        s = Snapshotter(os.path.join(tmp, "s.hdf5"), np.array(["a"]))
+        with mod.snapshot_on_signal(s):
+            assert signal.getsignal(signal.SIGTERM) is not before_term
+        assert signal.getsignal(signal.SIGTERM) is before_term
+        assert signal.getsignal(signal.SIGINT) is before_int
+        # a wakeup fd left behind would make Python write signal bytes into a
+        # closed descriptor for the rest of the process's life
+        current = signal.set_wakeup_fd(-1)
+        assert current == -1, f"wakeup fd left set to {current}"


### PR DESCRIPTION
Independent of #153 and #154 — branched from `main`, one new module plus small
hooks.

> **Reviewing `fitter.py`:** the minimizer's `while True:` loop is indented by
> four spaces to sit inside a `with snapshot_on_signal(...)` block, so git pairs
> the old and new copies line by line and renders the whole loop as rewritten —
> existing `break`s and comments included. Nothing in it changed:
> `git diff -w upstream/main..HEAD -- rabbit/fitter.py` is the real change, **33
> lines added and 1 removed**, and the loop still has the same three `break`
> statements and the same comments, byte for byte.

## The problem

Everything a fit has learned lives in one in-memory vector until the output
file is written at the very end. A fit that is killed, hits a wall clock limit,
or dies on the way to its output leaves **nothing at all** behind, however close
to the minimum it had got. That is cheap for a five-minute fit and expensive for
one that has been running for days.

## What this adds

`rabbit/snapshot.py` writes that vector to disk. A snapshot is deliberately the
smallest thing `load_fitresult` accepts — the parameter values and their names —
so it resumes through the path that already exists, with no new format and no
change to how results are read:

```bash
rabbit_fit.py input.hdf5 -o out/ --externalPostfit snapshot.hdf5           # carry on
rabbit_fit.py input.hdf5 -o out/ --externalPostfit snapshot.hdf5 --noFit   # postfit only
```

No covariance is stored: it does not exist until the Hessian is computed, and
`load_fitresult` already treats it as optional. Bin-by-bin parameters are
re-profiled on load. A snapshot is a few hundred kB.

## When one is written

| trigger | covers |
|---|---|
| SIGINT / SIGTERM | wall clock limits, and `kill` on a fit someone decided to stop |
| the minimizer raises | a failure that would otherwise discard the whole fit |
| convergence | the stretch between the minimum and the output being closed — on a large model the Hessian, the impacts and the postfit histograms |
| every N hours | `--snapshotInterval`, off by default |

The first three do not depend on `--snapshotInterval`. Nothing is written unless
`--snapshotFile` or `--snapshotInterval` is given; with an interval and no
filename it defaults to `<outdir>/<outname>_snapshot.hdf5`.

## Three details that are load-bearing

**The values written are physical.** Under preconditioning the minimizer's
iterate is in internal coordinates, and a snapshot of those would load without
complaint and be silently wrong. Conversion happens when the point is *recorded*
rather than when it is written, which also closes a window that would otherwise
be minutes wide: during a preconditioner rebuild the stored transform no longer
matches the stored iterate.

**The write is atomic.** Snapshots exist for processes dying at moments they did
not choose, and that includes mid-write. Writing in place would leave a truncated
file where a good one used to be, making the safety net the thing that destroys
the result. Each snapshot goes to a temporary file in the same directory
(`os.replace` is only atomic within a filesystem) and is moved into place.

**The signal snapshot is written from a thread, not the signal handler.**
Python runs signal handlers only in the main thread, between bytecodes, and this
fit spends its time inside single TensorFlow calls lasting minutes — one
iteration took 910 s. A handler-based write is therefore never dispatched: a
preempted 22-hour production fit wrote **33 periodic snapshots and zero signal
ones** before SIGKILL. A cooperative "stop at the next iteration" fails the same
way, only worse.

So `set_wakeup_fd` writes the signal number to a pipe — immediately, and without
needing the GIL — and a daemon thread blocked on the read end does the snapshot.
TensorFlow releases the GIL during a long op, so that thread runs while the main
thread is still down in C. The Python-level handler alongside is deliberately a
no-op; its only job is to make the signal count as handled so the wakeup fd
fires.

The thread then exits with `128+signum` rather than re-raising, because
restoring the default disposition needs `signal.signal()`, which only works from
the main thread — the very thread that is stuck. **The process therefore reports
exit 143 rather than killed-by-SIGTERM.** That is the price of being able to act
at all, and by then the snapshot is already on disk.

## Notes

`rabbit.snapshot` imports neither the fitter nor TensorFlow. That is what makes
it usable from a signal handler and testable in a subprocess that starts in
seconds instead of minutes (importing TensorFlow currently costs over two
minutes on a loaded machine).

The diff to `fitter.py` looks larger than it is: ignoring whitespace it is 33
lines added and 1 removed, the rest being the minimizer loop reindenting into a
`with` block.

This does not checkpoint the minimizer's internal state — trust radius, Lanczos
basis, preconditioner — so a resumed fit restarts its trust region at the
snapshot point. Near a minimum that is cheap; mid-descent it costs some
re-convergence.

## Testing

Note the periodic interval is the load-bearing protection for fits with long
iterations; the signal path is a second line, not the primary one.

## Testing

`tests/test_snapshot.py` covers the round trip through the real
`load_fitresult` (so it fails if the layout ever drifts from what
`--externalPostfit` accepts), that the preconditioner is undone, that a rebuilt
transform does not retroactively remap an older iterate, that a failed write
leaves the previous snapshot intact and no temporary file behind, the interval
logic, and — in a subprocess — that SIGTERM leaves a correct snapshot on disk while
the main thread is **blocked in a C call**.

That last point matters: the original test blocked the main thread in
`time.sleep`, which is interruptible, so it passed whether or not the mechanism
worked — that is how the bug shipped. It now blocks in `np.sort` (single-
threaded and predictable, unlike a matmul whose BLAS thread count varies with
size: a call sized for 25 s ran in 0.58 s on a 768-core box), asserts the
process dies within 15 s, and **fails loudly if the blocking call finished
first**, so a run that does not exercise a blocked main thread cannot pass
quietly. 76 tests pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rYVNwxQvuUYz5z9wt6ddb


