### PR TITLE
preconditioner: spectral transform as an option, block-membership logging, and a ridge fix

### DIFF
--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -105,9 +105,7 @@ class Fitter:
         self.precondition_params = getattr(options, "preconditionParams", None)
         self.precondition_from = getattr(options, "preconditionFrom", "hessian")
         self.precondition_blocks = getattr(options, "preconditionBlocks", "auto")
-        self.precondition_transform = getattr(
-            options, "preconditionTransform", "ridge"
-        )
+        self.precondition_transform = getattr(options, "preconditionTransform", "ridge")
         self.precondition_block_threshold = getattr(
             options, "preconditionBlockThreshold", 0.1
         )

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -2316,7 +2316,16 @@ class Fitter:
         # formed (memory, or a tracing failure on a large model) fall back to an
         # unpreconditioned fit rather than taking the whole job down.
         try:
+            _t_ref = time.time()
             hess_np = self._reference_matrix()
+            # Time it: this is a FULL Hessian at the current point, and it is
+            # the entire cost of a preconditioner rebuild. Whether restarting
+            # aggressively is worth it is exactly this number against the
+            # remaining iterations, so it should not have to be guessed.
+            logger.debug(
+                f"Preconditioner reference matrix ({self.precondition_from}) "
+                f"took {time.time() - _t_ref:.1f} s"
+            )
         except Exception as ex:
             logger.warning(
                 f"Could not compute the reference Hessian for preconditioning ({ex}); "
@@ -2351,8 +2360,10 @@ class Fitter:
             transform=self.precondition_transform,
             # names so the per-block log says WHICH parameters each block holds;
             # "block of 14 parameters" alone leaves no way to tell from a log
-            # which directions the transform actually helped.
-            names=[str(p) for p in self.parms],
+            # which directions the transform actually helped. astype(str), not
+            # str() per element: indata.systs comes out of h5py as an object
+            # array of bytes, so str() would render every name as b'...'.
+            names=self.parms.astype(str),
         )
 
     def fit(self):

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -2347,6 +2347,10 @@ class Fitter:
             theta_ref,
             index_blocks,
             ridge=self.precondition_ridge,
+            # names so the per-block log says WHICH parameters each block holds;
+            # "block of 14 parameters" alone leaves no way to tell from a log
+            # which directions the transform actually helped.
+            names=[str(p) for p in self.parms],
         )
 
     def fit(self):

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -105,6 +105,9 @@ class Fitter:
         self.precondition_params = getattr(options, "preconditionParams", None)
         self.precondition_from = getattr(options, "preconditionFrom", "hessian")
         self.precondition_blocks = getattr(options, "preconditionBlocks", "auto")
+        self.precondition_transform = getattr(
+            options, "preconditionTransform", "ridge"
+        )
         self.precondition_block_threshold = getattr(
             options, "preconditionBlockThreshold", 0.1
         )
@@ -2347,6 +2350,7 @@ class Fitter:
             theta_ref,
             index_blocks,
             ridge=self.precondition_ridge,
+            transform=self.precondition_transform,
             # names so the per-block log says WHICH parameters each block holds;
             # "block of 14 parameters" alone leaves no way to tell from a log
             # which directions the transform actually helped.

--- a/rabbit/parsing.py
+++ b/rabbit/parsing.py
@@ -257,7 +257,7 @@ def common_parser():
         "'expressions' makes one block per --preconditionParams entry. 'none' does "
         "no grouping at all and factorises the whole selected scope as a single "
         "block, which keeps every cross-correlation but is the most expensive and "
-        "fails entirely if any part of the scope is singular.",
+        "fails entirely if any part of the scope is singular. NOTE the purpose of blocking depends on the transform. Under 'ridge' it is a correctness tool: one scalar ridge cannot serve a block whose curvatures span orders of magnitude, so splitting protects the soft directions. Under 'spectral' a larger block is always better or equal -- it whitens the cross-terms exactly where splitting discards them (measured: one block of 8 gives condition number 1, the same matrix in two blocks gives 4.0) -- so blocking there only limits the O(m^3) cost, and 'none' is usually the right choice.",
     )
     parser.add_argument(
         "--preconditionBlockThreshold",
@@ -266,7 +266,7 @@ def common_parser():
         help="Correlation threshold for --preconditionBlocks auto. Correlations "
         "below it are left unpreconditioned. Too low and every parameter "
         "percolates into a single block; too high and genuinely coupled "
-        "parameters are split apart.",
+        "parameters are split apart. Only used by --preconditionBlocks auto. Under 'spectral' this threshold works against you: it splits away exactly the cross-correlations the spectral transform would have handled exactly, so 'every parameter percolates into a single block' is the IDEAL there rather than the warning it is under 'ridge'.",
     )
     parser.add_argument(
         "--preconditionFrom",
@@ -281,7 +281,7 @@ def common_parser():
         "exact Hessian is indefinite at the starting point, whitening with it leaves "
         "those directions negative and the fit stalls, so 'hessian' is usually the "
         "better choice; prefer 'gaussnewton' only where the Hessian is positive "
-        "definite anyway, e.g. near a minimum.",
+        "definite anyway, e.g. near a minimum. Under --preconditionTransform spectral there is no reason to choose gaussnewton: its PSD-ness exists to guarantee the Cholesky succeeds, which spectral does not need, and it still cannot represent negative curvature. Prefer 'hessian' there.",
     )
     parser.add_argument(
         "--preconditionRidge",
@@ -290,7 +290,28 @@ def common_parser():
         help="Ridge added to the preconditioning block diagonal, relative to its largest "
         "diagonal entry, to keep near-degenerate blocks factorisable. Escalated "
         "automatically if the Cholesky still fails; a block that cannot be factorised "
-        "falls back to no preconditioning.",
+        "falls back to no preconditioning. ONLY applies to --preconditionTransform ridge; the spectral transform derives its floor from the numerical rank instead.",
+    )
+    parser.add_argument(
+        "--preconditionTransform",
+        default="ridge",
+        type=str,
+        choices=["ridge", "spectral"],
+        help="How to whiten each block. 'ridge' (the default) factorises "
+        "H + eps*I, raising eps until the Cholesky succeeds. 'spectral' "
+        "factorises |H| = Q |Lambda| Q^T instead, giving every eigendirection "
+        "its own scale. They agree exactly on a positive definite block -- both "
+        "return the identity -- and differ where H is indefinite, which on real "
+        "data it generally is away from the minimum. A single scalar ridge must "
+        "be at least |lam_min| to restore definiteness, so in a block whose "
+        "curvatures span orders of magnitude it swamps every softer direction "
+        "and the whitening leaves them near-null: measured on curvatures "
+        "(3.3e9, -8.7e6, 1) the O(1) direction landed at 7e-08 and the block "
+        "went from condition number 3.3e+09 to 1.44e+08, where spectral gives "
+        "1. Spectral also handles a block whose whole diagonal is negative, "
+        "which the ridge cannot start on at all. It costs an eigendecomposition "
+        "rather than a Cholesky: measured 11x at m=200 and 44x at m=2112, i.e. "
+        "~1.7 s once per preconditioner build.",
     )
     parser.add_argument(
         "--snapshotFile",

--- a/rabbit/parsing.py
+++ b/rabbit/parsing.py
@@ -257,7 +257,10 @@ def common_parser():
         "'expressions' makes one block per --preconditionParams entry. 'none' does "
         "no grouping at all and factorises the whole selected scope as a single "
         "block, which keeps every cross-correlation but is the most expensive and "
-        "fails entirely if any part of the scope is singular. NOTE the purpose of blocking depends on the transform. Under 'ridge' it is a correctness tool: one scalar ridge cannot serve a block whose curvatures span orders of magnitude, so splitting protects the soft directions. Under 'spectral' a larger block is always better or equal -- it whitens the cross-terms exactly where splitting discards them (measured: one block of 8 gives condition number 1, the same matrix in two blocks gives 4.0) -- so blocking there only limits the O(m^3) cost, and 'none' is usually the right choice.",
+        "fails entirely if any part of the scope is singular. What blocking is "
+        "FOR depends on --preconditionTransform (under 'ridge' it is a "
+        "correctness tool, under 'spectral' only a cost limit): see CHOOSING "
+        "THE OPTIONS in rabbit/preconditioner.py.",
     )
     parser.add_argument(
         "--preconditionBlockThreshold",
@@ -266,7 +269,9 @@ def common_parser():
         help="Correlation threshold for --preconditionBlocks auto. Correlations "
         "below it are left unpreconditioned. Too low and every parameter "
         "percolates into a single block; too high and genuinely coupled "
-        "parameters are split apart. Only used by --preconditionBlocks auto. Under 'spectral' this threshold works against you: it splits away exactly the cross-correlations the spectral transform would have handled exactly, so 'every parameter percolates into a single block' is the IDEAL there rather than the warning it is under 'ridge'.",
+        "parameters are split apart. Only used by --preconditionBlocks auto, "
+        "and under --preconditionTransform spectral it works against you: see "
+        "CHOOSING THE OPTIONS in rabbit/preconditioner.py.",
     )
     parser.add_argument(
         "--preconditionFrom",
@@ -281,7 +286,9 @@ def common_parser():
         "exact Hessian is indefinite at the starting point, whitening with it leaves "
         "those directions negative and the fit stalls, so 'hessian' is usually the "
         "better choice; prefer 'gaussnewton' only where the Hessian is positive "
-        "definite anyway, e.g. near a minimum. Under --preconditionTransform spectral there is no reason to choose gaussnewton: its PSD-ness exists to guarantee the Cholesky succeeds, which spectral does not need, and it still cannot represent negative curvature. Prefer 'hessian' there.",
+        "definite anyway, e.g. near a minimum. Under --preconditionTransform "
+        "spectral there is no reason to choose 'gaussnewton' at all: see "
+        "CHOOSING THE OPTIONS in rabbit/preconditioner.py.",
     )
     parser.add_argument(
         "--preconditionRidge",
@@ -290,7 +297,9 @@ def common_parser():
         help="Ridge added to the preconditioning block diagonal, relative to its largest "
         "diagonal entry, to keep near-degenerate blocks factorisable. Escalated "
         "automatically if the Cholesky still fails; a block that cannot be factorised "
-        "falls back to no preconditioning. ONLY applies to --preconditionTransform ridge; the spectral transform derives its floor from the numerical rank instead.",
+        "falls back to no preconditioning. Applies to "
+        "--preconditionTransform ridge only; spectral derives its floor from "
+        "the numerical rank of the block instead.",
     )
     parser.add_argument(
         "--preconditionTransform",
@@ -301,17 +310,13 @@ def common_parser():
         "H + eps*I, raising eps until the Cholesky succeeds. 'spectral' "
         "factorises |H| = Q |Lambda| Q^T instead, giving every eigendirection "
         "its own scale. They agree exactly on a positive definite block -- both "
-        "return the identity -- and differ where H is indefinite, which on real "
-        "data it generally is away from the minimum. A single scalar ridge must "
-        "be at least |lam_min| to restore definiteness, so in a block whose "
-        "curvatures span orders of magnitude it swamps every softer direction "
-        "and the whitening leaves them near-null: measured on curvatures "
-        "(3.3e9, -8.7e6, 1) the O(1) direction landed at 7e-08 and the block "
-        "went from condition number 3.3e+09 to 1.44e+08, where spectral gives "
-        "1. Spectral also handles a block whose whole diagonal is negative, "
-        "which the ridge cannot start on at all. It costs an eigendecomposition "
-        "rather than a Cholesky: measured 11x at m=200 and 44x at m=2112, i.e. "
-        "~1.7 s once per preconditioner build.",
+        "return the identity -- and differ where H is indefinite, which away "
+        "from the minimum it generally is: one scalar ridge swamps every "
+        "direction softer than |lam_min| and leaves them near-null, where "
+        "spectral does not. Costs an eigendecomposition rather than a Cholesky, "
+        "~1.7 s once per build at m=2112. For the measurements, and for how "
+        "this interacts with the other --precondition* options, see WHITENING "
+        "EACH BLOCK in rabbit/preconditioner.py.",
     )
     parser.add_argument(
         "--snapshotFile",

--- a/rabbit/preconditioner.py
+++ b/rabbit/preconditioner.py
@@ -156,7 +156,9 @@ class Preconditioner:
         return max(c) if c else None
 
     @classmethod
-    def from_hessian(cls, hess, theta_ref, index_blocks, ridge=1e-8, max_tries=4):
+    def from_hessian(
+        cls, hess, theta_ref, index_blocks, ridge=1e-8, max_tries=4, names=None
+    ):
         """Build from a reference Hessian, one factorisation per index block.
 
         ``index_blocks`` is a list of index arrays (a single array is accepted
@@ -173,7 +175,12 @@ class Preconditioner:
         for spec in index_blocks:
             label, idx = ("", spec) if not isinstance(spec, tuple) else spec
             blk = cls._factorise(
-                hess, np.asarray(idx, dtype=np.int64), ridge, max_tries, label
+                hess,
+                np.asarray(idx, dtype=np.int64),
+                ridge,
+                max_tries,
+                label,
+                names=names,
             )
             if blk is not None:
                 blocks.append(blk)
@@ -189,19 +196,35 @@ class Preconditioner:
         n_req = len(index_blocks)
         npar = sum(b.idx.size for b in blocks)
         conds = [b.cond_before for b in blocks if b.cond_before is not None]
+        # Report the conditioning ACHIEVED, not a hardcoded 1. The literal "-> 1"
+        # this used to print claimed the transform had whitened every block
+        # perfectly, which is only true of the ridged matrix; measured on the
+        # un-ridged block (Block.cond_after) it can be worse than where it
+        # started -- seen at 1.8e+03 -> 1e+04 on a block whose ridge was forced
+        # up to |lam_min| by a large negative eigenvalue. A summary that cannot
+        # express that is worse than none, because it is read as success.
+        conds_after = [b.cond_after for b in blocks if b.cond_after is not None]
         summary = f"Preconditioned {len(blocks)} of {n_req} block(s), {npar} parameters"
         if conds:
             summary += (
                 f"; correlation condition number median {np.median(conds):.3g}, "
-                f"worst {max(conds):.3g} -> 1 at the reference point"
+                f"worst {max(conds):.3g}"
             )
+            if conds_after:
+                summary += (
+                    f" -> median {np.median(conds_after):.3g}, "
+                    f"worst {max(conds_after):.3g}"
+                )
+                if max(conds_after) > max(conds):
+                    summary += " (WORSE than unpreconditioned)"
+            summary += " at the reference point"
         if len(blocks) < n_req:
             summary += f" ({n_req - len(blocks)} block(s) not factorisable, skipped)"
         logger.info(summary)
         return cls(theta_ref, blocks)
 
     @staticmethod
-    def _factorise(hess, idx, ridge, max_tries, label=""):
+    def _factorise(hess, idx, ridge, max_tries, label="", names=None):
         """One block -> a :class:`Block`, or None if it is unusable."""
         tag = f"{label} " if label else ""
         if idx.size == 0:
@@ -217,7 +240,7 @@ class Preconditioner:
         if not np.isfinite(scale) or scale <= 0.0:
             logger.warning(
                 f"Preconditioning block {tag}has no positive diagonal "
-                f"(max diag = {scale}); skipping."
+                f"(max diag = {scale}); skipping.  [{_describe(idx, names)}]"
             )
             return None
 
@@ -269,11 +292,16 @@ class Preconditioner:
             tb = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
             tb = scipy.linalg.solve_triangular(chol, tb.T, lower=True, trans="N").T
             cond_after = _cond_corr(tb)
+            # Log the MEMBERS, not just the size: "block of 14 parameters" does
+            # not say which 14, so there is no way to tell from a log which
+            # parameters the transform actually helped. Names come from the
+            # optional `names` argument; without it this degrades to indices.
+            who = _describe(idx, names)
             logger.debug(
                 f"Preconditioning {tag}block of {idx.size} parameters from the "
                 f"reference Hessian (ridge {eps:.3g} x max|diag|): correlation "
                 f"condition number {cond_before:.3g} -> {cond_after:.3g} at the "
-                "reference point"
+                f"reference point  [{who}]"
             )
             return Block(idx, chol, cond_before, cond_after, label)
 
@@ -370,6 +398,21 @@ class Preconditioner:
             f"preconditioning: {self.n_blocks} block(s) covering "
             f"{self.nblock} of {self.n} parameters"
         )
+
+
+def _describe(idx, names=None, limit=8):
+    """Readable membership for a block: names when available, else indices."""
+    idx = np.asarray(idx).ravel()
+    if names is None:
+        out = [str(int(i)) for i in idx[:limit]]
+    else:
+        out = [
+            str(names[int(i)]) if int(i) < len(names) else str(int(i))
+            for i in idx[:limit]
+        ]
+    if idx.size > limit:
+        out.append(f"... +{idx.size - limit} more")
+    return ", ".join(out)
 
 
 def _cond_corr(mat):

--- a/rabbit/preconditioner.py
+++ b/rabbit/preconditioner.py
@@ -11,7 +11,9 @@ cost minutes and return a bit-identical loss.
 
 WHAT. We reparameterise. With theta the physical parameters, y the internal
 ones, theta_ref the point the transform was built at, and a reference Hessian
-H0 = L L^T restricted to a selected block:
+H0 = L L^T restricted to a selected block (away from a minimum H0 is
+generally indefinite and has no Cholesky -- see WHITENING EACH BLOCK below for
+the two ways to get an L):
 
     theta = theta_ref + T y,     T = L^-T   ->   T^T H0 T = I
 
@@ -44,6 +46,59 @@ inside the fit, so that failure mode does not arise.
 
 Parameters outside the selected blocks are passed through untouched, so the
 transform is a no-op there and a block can be as small as one wants.
+
+WHITENING EACH BLOCK. There are two ways to produce the L above, selected by
+--preconditionTransform (see :meth:`_factorise`):
+
+    'ridge' (default)  factorise H + eps*I, raising eps until the Cholesky
+                       succeeds. rabbit's original transform.
+    'spectral'         factorise |H| = Q |Lambda| Q^T, giving every
+                       eigendirection its own scale.
+
+They agree exactly on a positive definite block -- both return the identity,
+so nothing is lost on the easy ones -- and differ where H is indefinite. A
+single scalar ridge must be at least |lam_min| to restore definiteness, so in
+a block whose curvatures span orders of magnitude it swamps every direction
+softer than itself and the whitening leaves those near-null: measured on
+curvatures (3.3e9, -8.7e6, 1) the O(1) direction came out at 7e-08 and the
+block's true condition number went 3.3e+09 -> 1.44e+08, where spectral gives
+1. That is the genuine limitation of one scalar number, and the reason
+spectral exists.
+
+Spectral takes |Lambda| rather than clipping the spectrum to +eps, which keeps
+the SIGN of each direction in the new coordinates. That matters because
+trust-krylov exploits negative curvature to escape saddles, and flattening it
+to +1 throws that away. It costs an eigendecomposition rather than a Cholesky:
+measured 11x at m=200 and 44x at m=2112, i.e. ~1.7 s once per build, against a
+fit of tens of minutes.
+
+CHOOSING THE OPTIONS. The guidance for the neighbouring options *inverts* with
+the transform, so they are worth reading together rather than one --help
+string at a time:
+
+--preconditionBlocks
+    Under 'ridge' blocking is a *correctness* tool: one scalar ridge cannot
+    serve a block whose curvatures span orders of magnitude, so splitting
+    protects the soft directions. Under 'spectral' a larger block is always
+    better or equal, since it whitens the cross-terms exactly where splitting
+    discards them (measured: one block of 8 gives condition number 1, the same
+    matrix split in two gives 4.0). There, blocking only limits the O(m^3)
+    cost and 'none' is usually right.
+
+--preconditionBlockThreshold
+    Under 'spectral' this works against you: it splits away precisely the
+    correlations spectral handles exactly, so "every parameter percolates into
+    a single block" is the ideal there rather than the warning it is under
+    'ridge'.
+
+--preconditionFrom
+    Under 'spectral' there is no reason to pick 'gaussnewton': its PSD-ness
+    exists to guarantee the Cholesky succeeds, which spectral does not need,
+    and it still cannot represent negative curvature. Prefer 'hessian'.
+
+--preconditionRidge
+    Applies to 'ridge' only; spectral derives its floor from the numerical
+    rank of the block instead.
 
 FINDING THE BLOCKS. The clusters can be read off the reference matrix instead
 of being named by hand: threshold the correlation matrix and take connected
@@ -170,10 +225,17 @@ class Preconditioner:
 
         ``index_blocks`` is a list of index arrays (a single array is accepted
         and treated as one block). Each block is symmetrised and then whitened
-        by the Cholesky of ``|H| = Q |Lambda| Q^T`` -- see :meth:`_factorise`
-        for why the absolute value of the spectrum rather than a ridge. A block
-        that cannot be factorised is dropped: the others still apply, and a
-        preconditioner must never break a fit.
+        by ``transform``:
+
+        - ``'ridge'`` (the default) factorises ``H + eps*I``, escalating eps
+          until the Cholesky succeeds;
+        - ``'spectral'`` factorises ``|H| = Q |Lambda| Q^T``, giving each
+          eigendirection its own scale.
+
+        See :meth:`_factorise` for the dispatch and WHITENING EACH BLOCK in the
+        module docstring for which to prefer. A block that cannot be factorised
+        is dropped: the others still apply, and a preconditioner must never
+        break a fit.
         """
         if isinstance(index_blocks, np.ndarray) or (
             index_blocks and np.isscalar(index_blocks[0])
@@ -204,7 +266,6 @@ class Preconditioner:
         # finds hundreds, and the per-block detail is at debug level.
         n_req = len(index_blocks)
         npar = sum(b.idx.size for b in blocks)
-        conds = [b.cond_before for b in blocks if b.cond_before is not None]
         # Report the conditioning ACHIEVED, not a hardcoded 1. The literal "-> 1"
         # this used to print claimed the transform had whitened every block
         # perfectly, which is only true of the ridged matrix; measured on the
@@ -212,20 +273,27 @@ class Preconditioner:
         # started -- seen at 1.8e+03 -> 1e+04 on a block whose ridge was forced
         # up to |lam_min| by a large negative eigenvalue. A summary that cannot
         # express that is worse than none, because it is read as success.
-        conds_after = [b.cond_after for b in blocks if b.cond_after is not None]
+        #
+        # Paired, so the two medians are guaranteed to be over the same set of
+        # blocks. Both are set together on every success path, but filtering
+        # them independently would not enforce that.
+        pairs = [
+            (b.cond_before, b.cond_after)
+            for b in blocks
+            if b.cond_before is not None and b.cond_after is not None
+        ]
         summary = f"Preconditioned {len(blocks)} of {n_req} block(s), {npar} parameters"
-        if conds:
+        if pairs:
+            conds = [c for c, _ in pairs]
+            conds_after = [c for _, c in pairs]
             summary += (
                 f"; correlation condition number median {np.median(conds):.3g}, "
                 f"worst {max(conds):.3g}"
+                f" -> median {np.median(conds_after):.3g}, "
+                f"worst {max(conds_after):.3g}"
             )
-            if conds_after:
-                summary += (
-                    f" -> median {np.median(conds_after):.3g}, "
-                    f"worst {max(conds_after):.3g}"
-                )
-                if max(conds_after) > max(conds):
-                    summary += " (WORSE than unpreconditioned)"
+            if max(conds_after) > max(conds):
+                summary += " (WORSE than unpreconditioned)"
             summary += " at the reference point"
         if len(blocks) < n_req:
             summary += f" ({n_req - len(blocks)} block(s) not factorisable, skipped)"
@@ -236,26 +304,16 @@ class Preconditioner:
     def _factorise(
         hess, idx, ridge, max_tries, label="", names=None, transform="ridge"
     ):
-        """Dispatch to the requested transform. See --preconditionTransform."""
-        if transform == "spectral":
-            return Preconditioner._factorise_spectral(
-                hess, idx, ridge, max_tries, label=label, names=names
-            )
-        if transform == "ridge":
-            return Preconditioner._factorise_ridge(
-                hess, idx, ridge, max_tries, label=label, names=names
-            )
-        raise ValueError(f"unknown preconditioner transform {transform!r}")
+        """Whiten one block: shared preparation, then the requested transform.
 
-    @staticmethod
-    def _factorise_ridge(hess, idx, ridge, max_tries, label="", names=None):
-        """Ridge path: factorise ``H + eps*I``, escalating eps until it succeeds.
-
-        rabbit's original transform, kept as the default. A single scalar ridge
-        cannot serve a block whose curvatures span orders of magnitude -- see
-        :meth:`_factorise_spectral` and the note on --preconditionTransform --
-        so prefer spectral for heterogeneous blocks.
+        Returns a :class:`Block`, or None if the block is unusable. The
+        preparation (empty and finite checks, symmetrisation, and the
+        conditioning it started at) is common to both transforms; only the way
+        an L is obtained from an indefinite block differs. See
+        --preconditionTransform, and WHITENING EACH BLOCK in the module
+        docstring for which to prefer.
         """
+        idx = np.asarray(idx, dtype=np.int64)
         tag = f"{label} " if label else ""
         if idx.size == 0:
             logger.warning(f"Preconditioning block {tag}is empty; skipping.")
@@ -264,17 +322,58 @@ class Preconditioner:
         block = np.asarray(hess, dtype=np.float64)[np.ix_(idx, idx)]
         # symmetrise: the autodiff Hessian is symmetric only up to roundoff
         block = 0.5 * (block + block.T)
-
-        diag = np.diag(block)
-        scale = float(np.max(diag)) if diag.size else 0.0
-        if not np.isfinite(scale) or scale <= 0.0:
+        if not np.all(np.isfinite(block)):
             logger.warning(
-                f"Preconditioning block {tag}has no positive diagonal "
-                f"(max diag = {scale}); skipping.  [{_describe(idx, names)}]"
+                f"Preconditioning block {tag}is non-finite; skipping."
+                f"  [{_describe(idx, names)}]"
             )
             return None
 
         cond_before = _cond_corr(block)
+
+        if transform == "ridge":
+            return Preconditioner._factorise_ridge(
+                block, idx, cond_before, ridge, max_tries, label=label, names=names
+            )
+        if transform == "spectral":
+            return Preconditioner._factorise_spectral(
+                block, idx, cond_before, label=label, names=names
+            )
+        raise ValueError(f"unknown preconditioner transform {transform!r}")
+
+    @staticmethod
+    def _factorise_ridge(
+        block, idx, cond_before, ridge, max_tries, label="", names=None
+    ):
+        """Ridge path: factorise ``B + eps*I``, escalating eps until it succeeds.
+
+        rabbit's original transform, kept as the default. A single scalar ridge
+        cannot serve a block whose curvatures span orders of magnitude -- see
+        :meth:`_factorise_spectral` and the note on --preconditionTransform --
+        so prefer spectral for heterogeneous blocks.
+        """
+        tag = f"{label} " if label else ""
+
+        # The unit the ridge is expressed in, max|diag| rather than max(diag).
+        # It is only a scale: nothing in the schedule below needs it to come
+        # from a positive curvature, and requiring that used to skip every
+        # block with an all-negative diagonal outright -- 21 of 34 on one real
+        # fit, i.e. exactly the blocks most in need of help. Such a block fails
+        # the first Cholesky, then the spectrum branch at itry == 1 sizes the
+        # ridge from |lam_min| and it factorises (measured on diag(-7.5e3,
+        # -6.3e4, -2.1e3): skipped before, true cond_after 320 after). It is
+        # not as good as spectral, which reaches 1 on the same block, but a
+        # usable transform beats none. The log line already called this
+        # "max|diag|".
+        diag = np.diag(block)
+        scale = float(np.max(np.abs(diag))) if diag.size else 0.0
+        if not np.isfinite(scale) or scale <= 0.0:
+            logger.warning(
+                f"Preconditioning block {tag}has an all-zero diagonal "
+                f"(max|diag| = {scale}); skipping.  [{_describe(idx, names)}]"
+            )
+            return None
+
         # Ridge schedule: try the caller's value first, since for a positive
         # definite block that is all that is needed and the Cholesky is cheap.
         # Only if that fails is the spectrum worth the extra O(m^3): the ridge
@@ -319,47 +418,38 @@ class Preconditioner:
             # Conditioning actually achieved: L^-1 B L^-T for the *un-ridged*
             # block B. Using the ridged matrix here would return 1 by
             # construction and measure nothing.
-            tb = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
-            tb = scipy.linalg.solve_triangular(chol, tb.T, lower=True, trans="N").T
-            cond_after = _cond_corr(tb)
+            cond_after = _cond_corr(_whiten(chol, block))
             logger.debug(
                 f"Preconditioning {tag}block of {idx.size} parameters from the "
                 f"reference Hessian (ridge {eps:.3g} x max|diag|): correlation "
                 f"condition number {cond_before:.3g} -> {cond_after:.3g} at the "
-                "reference point"
+                f"reference point  [{_describe(idx, names)}]"
             )
             return Block(idx, chol, cond_before, cond_after, label)
 
         logger.warning(
             f"Preconditioning block {tag}is not factorisable; the largest ridge "
             f"tried was {max(schedule):.3g} x max|diag|. Skipping this block."
+            f"  [{_describe(idx, names)}]"
         )
         return None
 
     @staticmethod
-    def _factorise_spectral(hess, idx, ridge, max_tries, label="", names=None):
-        """One block -> a :class:`Block`, or None if it is unusable."""
+    def _factorise_spectral(block, idx, cond_before, label="", names=None):
+        """Spectral path: whiten by the Cholesky of ``|B| = Q |Lambda| Q^T``.
+
+        Gives every eigendirection its own scale, so unlike the ridge it serves
+        a block whose curvatures span orders of magnitude, and it can start on
+        a block with no positive curvature at all. Identical in result to the
+        plain Cholesky where the block is positive definite. Takes |Lambda|
+        rather than clipping, which preserves the sign of each direction --
+        trust-krylov needs the negative ones. See the comment below and
+        WHITENING EACH BLOCK in the module docstring.
+        """
         tag = f"{label} " if label else ""
-        if idx.size == 0:
-            logger.warning(f"Preconditioning block {tag}is empty; skipping.")
-            return None
 
-        block = np.asarray(hess, dtype=np.float64)[np.ix_(idx, idx)]
-        # symmetrise: the autodiff Hessian is symmetric only up to roundoff
-        block = 0.5 * (block + block.T)
-
-        diag = np.diag(block)
-        if diag.size == 0 or not np.all(np.isfinite(block)):
-            logger.warning(
-                f"Preconditioning block {tag}is empty or non-finite; skipping."
-                f"  [{_describe(idx, names)}]"
-            )
-            return None
-
-        cond_before = _cond_corr(block)
-
-        # SPECTRAL whitening: factorise |H| = Q |Lambda| Q^T rather than
-        # ridging H into definiteness.
+        # SPECTRAL whitening: factorise |B| = Q |Lambda| Q^T rather than
+        # ridging B into definiteness.
         #
         # Why not a ridge. A ridge is ONE number and it has to be at least
         # |lam_min| to restore definiteness, so in a block whose curvatures span
@@ -414,15 +504,23 @@ class Preconditioner:
         # and the block comes out at condition number 33 instead of 1
         # (tests/test_preconditioner_spectral.py pins exactly this).
         #
-        # `ridge` and `max_tries` are unused on THIS path (they belong to the
-        # ridge transform); the signature is shared so the dispatcher can call
-        # either without special-casing.
+        # What this bounds is 1/sqrt(floor), so the protection is finite, not
+        # absolute: on diag(1, 1e-18) it takes max|L^-1| from 1e9 to 4.7e7, a
+        # factor of ~21. That is a step the trust region can still reject
+        # rather than one that overflows it.
         floor = float(np.finfo(np.float64).eps) * float(idx.size) * wmax
         n_floored = int(np.count_nonzero(aw < floor))
         aw = np.maximum(aw, floor if floor > 0 else np.finfo(float).tiny)
 
         absH = (Q * aw) @ Q.T
         absH = 0.5 * (absH + absH.T)
+        # Cholesky of |B|, rather than the symmetric square root Q sqrt(|Lambda|)
+        # which is already in hand: Block caches an explicit L^-1 but falls back
+        # to a triangular solve when it cannot be formed (see _apply_T), so L
+        # has to be lower triangular. The cost is a second O(m^3), and it can
+        # itself fail on a floored spectrum -- cond(|B|) is then ~1/(eps*m),
+        # i.e. ~4e14 -- which is why this is caught and the block skipped rather
+        # than assumed to succeed.
         try:
             chol = scipy.linalg.cholesky(absH, lower=True)
         except scipy.linalg.LinAlgError as ex:
@@ -432,11 +530,9 @@ class Preconditioner:
             )
             return None
 
-        # Conditioning actually achieved, on the UN-modified block: using |H|
+        # Conditioning actually achieved, on the UN-modified block: using |B|
         # here would return 1 by construction and measure nothing.
-        tb = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
-        tb = scipy.linalg.solve_triangular(chol, tb.T, lower=True, trans="N").T
-        cond_after = _cond_corr(tb)
+        cond_after = _cond_corr(_whiten(chol, block))
         n_neg = int(np.count_nonzero(w < 0.0))
         logger.debug(
             f"Preconditioning {tag}block of {idx.size} parameters by spectral "
@@ -549,6 +645,12 @@ def _describe(idx, names=None, limit=8):
     if idx.size > limit:
         out.append(f"... +{idx.size - limit} more")
     return ", ".join(out)
+
+
+def _whiten(chol, block):
+    """``L^-1 B L^-T``: the block as the minimizer sees it after the transform."""
+    t = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
+    return scipy.linalg.solve_triangular(chol, t.T, lower=True, trans="N").T
 
 
 def _cond_corr(mat):

--- a/rabbit/preconditioner.py
+++ b/rabbit/preconditioner.py
@@ -100,6 +100,42 @@ string at a time:
     Applies to 'ridge' only; spectral derives its floor from the numerical
     rank of the block instead.
 
+WHAT THE NUMBERS MEAN. Two different questions get asked about a block, and
+conflating them is how a preconditioner comes to look like it worked:
+
+    condition number   kappa of the block itself (:func:`_cond_true`). This is
+                       what the minimizer feels -- the Krylov inner solve costs
+                       ~sqrt(kappa) Hessian-vector products -- so it is the
+                       number a transform has to reduce, and it is reported at
+                       BOTH ends of the before/after arrow.
+    degeneracy         kappa of the block's CORRELATION matrix
+                       (:func:`_cond_corr`), i.e. after normalising to unit
+                       diagonal. Scale-free, so it isolates genuine
+                       near-linear-dependence from a mismatch of units.
+
+The degeneracy is reported for the block as it ARRIVES only, where the units
+are an arbitrary convention and factoring them out is the right thing to do.
+It is deliberately not reported for the whitened block, for two reasons:
+
+- the units there are not arbitrary -- they are precisely what the transform
+  chose, and flattening them hides the failure mode of a single scalar ridge,
+  which swamps every direction softer than |lam_min| and leaves them near-null
+  (measured: 1.225 -> 1 by correlation, where the truth is 3.3e9 -> 1.4e8);
+- on the spectral path it is not even an approximation, it is an artefact. B
+  and |B| share eigenvectors, so with |B| = L L^T the congruence L^-1 B L^-T
+  sends Lambda to its own signature: tb is symmetric AND orthogonal, tb^2 = I,
+  and true kappa is identically 1 for any block size. But L is a Cholesky
+  factor, not the eigenbasis, so diag(tb) is only bounded by [-1, 1] and the
+  1/sqrt|diag| normalisation picks up the arbitrary orientation between the
+  two. Measured on random indefinite blocks, the correlation number then reads
+  1.7 at m=5, 7.7 at m=12, 21 at m=30, 34 at m=60 -- growing with block size,
+  i.e. worst exactly where --preconditionBlocks none sends you -- while the
+  true value is 1 throughout.
+
+  The identity holds only where nothing was floored: a floored direction is one
+  the congruence no longer preserves, so n_floored > 0 legitimately takes true
+  kappa away from 1. That is why it is measured per block rather than assumed.
+
 FINDING THE BLOCKS. The clusters can be read off the reference matrix instead
 of being named by hand: threshold the correlation matrix and take connected
 components (see :func:`auto_blocks`). On the in-situ efficiency fit that
@@ -140,15 +176,27 @@ PRECONDITION_SOURCES = ("hessian", "gaussnewton")
 class Block:
     """One factorised group of parameters: indices, L, and a cached L^-1."""
 
-    def __init__(self, idx, chol, cond_before=None, cond_after=None, label=""):
+    def __init__(
+        self,
+        idx,
+        chol,
+        cond_before=None,
+        cond_after=None,
+        label="",
+        corr_before=None,
+    ):
         self.idx = np.asarray(idx, dtype=np.int64)
         self.chol = np.asarray(chol, dtype=np.float64)
         if self.chol.shape != (self.idx.size,) * 2:
             raise ValueError(
                 f"chol shape {self.chol.shape} does not match block size {self.idx.size}"
             )
+        # cond_* are TRUE condition numbers, comparable at both ends.
+        # corr_before is the scale-free degeneracy of the incoming block; there
+        # is deliberately no corr_after (module docstring).
         self.cond_before = cond_before
         self.cond_after = cond_after
+        self.corr_before = corr_before
         self.label = label
         # Explicit L^-1, formed once so the per-call transform is a dense matvec
         # (parallel GEMV) instead of a triangular solve (inherently sequential).
@@ -274,6 +322,10 @@ class Preconditioner:
         # up to |lam_min| by a large negative eigenvalue. A summary that cannot
         # express that is worse than none, because it is read as success.
         #
+        # The arrow is the TRUE condition number at both ends, so it compares
+        # like with like; the scale-free degeneracy is a separate clause rather
+        # than the other end of an arrow. See WHAT THE NUMBERS MEAN.
+        #
         # Paired, so the two medians are guaranteed to be over the same set of
         # blocks. Both are set together on every success path, but filtering
         # them independently would not enforce that.
@@ -287,7 +339,7 @@ class Preconditioner:
             conds = [c for c, _ in pairs]
             conds_after = [c for _, c in pairs]
             summary += (
-                f"; correlation condition number median {np.median(conds):.3g}, "
+                f"; condition number median {np.median(conds):.3g}, "
                 f"worst {max(conds):.3g}"
                 f" -> median {np.median(conds_after):.3g}, "
                 f"worst {max(conds_after):.3g}"
@@ -295,6 +347,12 @@ class Preconditioner:
             if max(conds_after) > max(conds):
                 summary += " (WORSE than unpreconditioned)"
             summary += " at the reference point"
+            corrs = [b.corr_before for b in blocks if b.corr_before is not None]
+            if corrs:
+                summary += (
+                    f"; of which degeneracy (scale-free) median "
+                    f"{np.median(corrs):.3g}, worst {max(corrs):.3g}"
+                )
         if len(blocks) < n_req:
             summary += f" ({n_req - len(blocks)} block(s) not factorisable, skipped)"
         logger.info(summary)
@@ -329,21 +387,29 @@ class Preconditioner:
             )
             return None
 
-        cond_before = _cond_corr(block)
+        cond_before = _cond_true(block)
+        corr_before = _cond_corr(block)
 
         if transform == "ridge":
             return Preconditioner._factorise_ridge(
-                block, idx, cond_before, ridge, max_tries, label=label, names=names
+                block,
+                idx,
+                cond_before,
+                corr_before,
+                ridge,
+                max_tries,
+                label=label,
+                names=names,
             )
         if transform == "spectral":
             return Preconditioner._factorise_spectral(
-                block, idx, cond_before, label=label, names=names
+                block, idx, cond_before, corr_before, label=label, names=names
             )
         raise ValueError(f"unknown preconditioner transform {transform!r}")
 
     @staticmethod
     def _factorise_ridge(
-        block, idx, cond_before, ridge, max_tries, label="", names=None
+        block, idx, cond_before, corr_before, ridge, max_tries, label="", names=None
     ):
         """Ridge path: factorise ``B + eps*I``, escalating eps until it succeeds.
 
@@ -418,14 +484,17 @@ class Preconditioner:
             # Conditioning actually achieved: L^-1 B L^-T for the *un-ridged*
             # block B. Using the ridged matrix here would return 1 by
             # construction and measure nothing.
-            cond_after = _cond_corr(_whiten(chol, block))
+            cond_after = _cond_true(_whiten(chol, block))
             logger.debug(
                 f"Preconditioning {tag}block of {idx.size} parameters from the "
-                f"reference Hessian (ridge {eps:.3g} x max|diag|): correlation "
-                f"condition number {cond_before:.3g} -> {cond_after:.3g} at the "
-                f"reference point  [{_describe(idx, names)}]"
+                f"reference Hessian (ridge {eps:.3g} x max|diag|): condition "
+                f"number {cond_before:.3g} -> {cond_after:.3g}, of which "
+                f"degeneracy {corr_before:.3g}, at the reference point"
+                f"  [{_describe(idx, names)}]"
             )
-            return Block(idx, chol, cond_before, cond_after, label)
+            return Block(
+                idx, chol, cond_before, cond_after, label, corr_before=corr_before
+            )
 
         logger.warning(
             f"Preconditioning block {tag}is not factorisable; the largest ridge "
@@ -435,7 +504,7 @@ class Preconditioner:
         return None
 
     @staticmethod
-    def _factorise_spectral(block, idx, cond_before, label="", names=None):
+    def _factorise_spectral(block, idx, cond_before, corr_before, label="", names=None):
         """Spectral path: whiten by the Cholesky of ``|B| = Q |Lambda| Q^T``.
 
         Gives every eigendirection its own scale, so unlike the ridge it serves
@@ -532,16 +601,25 @@ class Preconditioner:
 
         # Conditioning actually achieved, on the UN-modified block: using |B|
         # here would return 1 by construction and measure nothing.
-        cond_after = _cond_corr(_whiten(chol, block))
+        #
+        # On this path the answer is 1 by a stronger argument, and it is worth
+        # knowing when reading the log: B and |B| share eigenvectors, so with
+        # |B| = L L^T the congruence L^-1 B L^-T sends Lambda to its own
+        # signature, i.e. tb is symmetric AND orthogonal (tb^2 = I) and true
+        # kappa is identically 1 at any block size. It is still measured rather
+        # than asserted, because n_floored > 0 breaks exactly that identity --
+        # a floored direction is one the congruence no longer preserves.
+        cond_after = _cond_true(_whiten(chol, block))
         n_neg = int(np.count_nonzero(w < 0.0))
         logger.debug(
             f"Preconditioning {tag}block of {idx.size} parameters by spectral "
             f"whitening of |H| (lam in [{w[0]:.3g}, {w[-1]:.3g}], {n_neg} "
-            f"negative, {n_floored} floored): correlation condition number "
-            f"{cond_before:.3g} -> {cond_after:.3g} at the reference point"
+            f"negative, {n_floored} floored): condition number "
+            f"{cond_before:.3g} -> {cond_after:.3g}, of which degeneracy "
+            f"{corr_before:.3g}, at the reference point"
             f"  [{_describe(idx, names)}]"
         )
-        return Block(idx, chol, cond_before, cond_after, label)
+        return Block(idx, chol, cond_before, cond_after, label, corr_before=corr_before)
 
     # -- the transform ---------------------------------------------------
 
@@ -653,12 +731,32 @@ def _whiten(chol, block):
     return scipy.linalg.solve_triangular(chol, t.T, lower=True, trans="N").T
 
 
+def _cond_true(mat):
+    """Condition number of ``mat`` itself: what the minimizer actually feels.
+
+    The Krylov inner solve converges in a number of Hessian-vector products
+    growing like sqrt of this, so it -- not the correlation number below -- is
+    the quantity a transform has to reduce. Reported for both ends of the
+    before/after pair, since after the transform the parameter scales are
+    precisely what was chosen rather than an arbitrary unit convention.
+    """
+    mat = np.asarray(mat, dtype=np.float64)
+    if mat.size == 0 or not np.all(np.isfinite(mat)):
+        return np.inf
+    try:
+        sv = np.linalg.svd(mat, compute_uv=False)
+    except np.linalg.LinAlgError:
+        return np.inf
+    return float(sv[0] / sv[-1]) if sv[-1] > 0 else np.inf
+
+
 def _cond_corr(mat):
     """Condition number of the *correlation* matrix of ``mat``.
 
     Scale-invariant, so it measures genuine degeneracy rather than a mismatch
-    of units between parameters -- the quantity that actually governs how hard
-    the block is to fit.
+    of units between parameters. Reported for the block as it arrives, where
+    the units genuinely are arbitrary; NOT for the whitened block, where it is
+    an artefact -- see WHAT THE NUMBERS MEAN in the module docstring.
     """
     d = np.sqrt(np.abs(np.diag(mat)))
     good = d > 0

--- a/rabbit/preconditioner.py
+++ b/rabbit/preconditioner.py
@@ -136,6 +136,41 @@ It is deliberately not reported for the whitened block, for two reasons:
   the congruence no longer preserves, so n_floored > 0 legitimately takes true
   kappa away from 1. That is why it is measured per block rather than assumed.
 
+NEVER MAKE IT WORSE. A block is dropped if it cannot be factorised, and also
+if whitening it would make its TRUE condition number worse by more than
+DEGRADE_TOLERANCE. The second half matters because succeeding badly is not
+obviously better than failing: whitening a block whose whole spectrum is
+negative needs a ridge of at least |lam_min| ~ max|diag|, which swamps every
+direction in it. Measured over 7094 such blocks across four off-diagonal
+strengths, the ridge degraded the true condition number in 100% of them, median
+10.8x, and improved none. Dropping restores exactly the unpreconditioned
+behaviour, so a fit can never come out worse on that block than with
+--precondition off.
+
+The guard keys off the true condition number, not the correlation one, which is
+blind to the clean case: a diagonal block has the identity as its correlation
+matrix both before and after, so diag(-7.5e3, -6.3e4, -2.1e3) reports 1 -> 1
+where the truth is 30 -> 320.
+
+It does not act on a block that is already singular to working precision
+(SINGULAR_COND). There the true condition number stops being a measurement --
+one rank-deficient block reads 5.28e+16 -> 7.32e+16, a 1.39x "degradation"
+between two values past 1/eps -- while the correlation number shows the ridge
+genuinely helping it, 3.1e+16 -> 1.4e+12. Ridging a rank-deficient block into
+shape is what the ridge was for in the first place, so that behaviour is left
+alone. It is the mirror image of the all-negative case, and the reason both
+metrics are kept rather than one being declared the right one.
+
+One consequence worth being plain about. Expressing the ridge in units of
+max|diag| rather than max(diag) means an all-negative block is now reachable at
+all -- it used to be rejected before any factorisation was attempted -- but
+since ridging such a block essentially never helps, the guard then drops it
+again. The net behaviour for those blocks is the same as before; what changed is
+that it is now arrived at by measurement, with a logged reason, rather than by a
+scale test that was mislabelled (it always said "max|diag|"), and that the same
+protection now covers every other block too. The spectral transform is what
+actually rescues them: it reaches 1 on the same block.
+
 FINDING THE BLOCKS. The clusters can be read off the reference matrix instead
 of being named by hand: threshold the correlation matrix and take connected
 components (see :func:`auto_blocks`). On the in-situ efficiency fit that
@@ -171,6 +206,20 @@ logger = logging.child_logger(__name__)
 
 # Sources for the reference matrix, built by the fitter (see Fitter._reference_matrix).
 PRECONDITION_SOURCES = ("hessian", "gaussnewton")
+
+# A block is dropped if whitening makes its true condition number worse by more
+# than this factor. Not zero, so that a tie or a rounding difference does not
+# churn a block in and out; small, because there is no reason to accept a
+# transform that measurably degrades what it was applied to. See
+# NEVER MAKE IT WORSE in the module docstring.
+DEGRADE_TOLERANCE = 0.01
+
+# Above this the block is singular to working precision and its condition
+# number is not a measurement any more, so the degradation guard does not act
+# on it: "worse" is not decidable between two values of order 1/eps, and
+# ridging a rank-deficient block into shape is the ridge's original purpose
+# (tests/test_preconditioner.py::test_rank_deficient_block_is_ridged_into_shape).
+SINGULAR_COND = 1.0 / np.finfo(np.float64).eps
 
 
 class Block:
@@ -391,7 +440,7 @@ class Preconditioner:
         corr_before = _cond_corr(block)
 
         if transform == "ridge":
-            return Preconditioner._factorise_ridge(
+            blk = Preconditioner._factorise_ridge(
                 block,
                 idx,
                 cond_before,
@@ -401,11 +450,54 @@ class Preconditioner:
                 label=label,
                 names=names,
             )
-        if transform == "spectral":
-            return Preconditioner._factorise_spectral(
+        elif transform == "spectral":
+            blk = Preconditioner._factorise_spectral(
                 block, idx, cond_before, corr_before, label=label, names=names
             )
-        raise ValueError(f"unknown preconditioner transform {transform!r}")
+        else:
+            raise ValueError(f"unknown preconditioner transform {transform!r}")
+
+        # NEVER MAKE IT WORSE. from_hessian already drops a block that cannot be
+        # factorised, on the principle that a preconditioner must never break a
+        # fit -- but that was applied only to factorisation FAILING, never to it
+        # succeeding and making things worse. Whitening a block whose whole
+        # spectrum is negative is exactly that case: the ridge has to be at
+        # least |lam_min| ~ max|diag|, so it swamps every direction in the
+        # block. Measured over 7094 such blocks across four off-diagonal
+        # strengths, the ridge degraded the true condition number in 100% of
+        # them, median 10.8x, and improved NONE.
+        #
+        # Dropping the block restores exactly the unpreconditioned behaviour
+        # there, so the fit can never come out worse than with --precondition
+        # off on that block, and the guard covers the pre-existing ridge path
+        # too rather than only the blocks the max|diag| fix newly reaches.
+        #
+        # It has to key off the TRUE condition number. The correlation number
+        # catches most of these but is blind to the clean case: a diagonal block
+        # has the identity as its correlation matrix both before and after, so
+        # diag(-7.5e3, -6.3e4, -2.1e3) reports 1 -> 1 while the truth is
+        # 30 -> 320. It is also why the guard must not run on corr_before.
+        # Not applied to an already-singular block: see SINGULAR_COND. There
+        # the true condition number is noise at the 1e16 level -- one such
+        # block measures 5.28e+16 -> 7.32e+16, a "degradation" of 1.39x between
+        # two numbers past 1/eps -- while the correlation number shows the ridge
+        # genuinely helping it (3.1e+16 -> 1.4e+12). That is the mirror image of
+        # the all-negative case above, and the reason the two metrics are both
+        # kept rather than one being declared correct.
+        if (
+            blk is not None
+            and blk.cond_before is not None
+            and blk.cond_after is not None
+            and blk.cond_before < SINGULAR_COND
+            and blk.cond_after > blk.cond_before * (1.0 + DEGRADE_TOLERANCE)
+        ):
+            logger.warning(
+                f"Preconditioning block {tag}would make the conditioning WORSE "
+                f"({blk.cond_before:.3g} -> {blk.cond_after:.3g}); leaving it "
+                f"unpreconditioned.  [{_describe(idx, names)}]"
+            )
+            return None
+        return blk
 
     @staticmethod
     def _factorise_ridge(

--- a/rabbit/preconditioner.py
+++ b/rabbit/preconditioner.py
@@ -157,7 +157,14 @@ class Preconditioner:
 
     @classmethod
     def from_hessian(
-        cls, hess, theta_ref, index_blocks, ridge=1e-8, max_tries=4, names=None
+        cls,
+        hess,
+        theta_ref,
+        index_blocks,
+        ridge=1e-8,
+        max_tries=4,
+        names=None,
+        transform="ridge",
     ):
         """Build from a reference Hessian, one factorisation per index block.
 
@@ -182,6 +189,7 @@ class Preconditioner:
                 max_tries,
                 label,
                 names=names,
+                transform=transform,
             )
             if blk is not None:
                 blocks.append(blk)
@@ -225,7 +233,111 @@ class Preconditioner:
         return cls(theta_ref, blocks)
 
     @staticmethod
-    def _factorise(hess, idx, ridge, max_tries, label="", names=None):
+    def _factorise(
+        hess, idx, ridge, max_tries, label="", names=None, transform="ridge"
+    ):
+        """Dispatch to the requested transform. See --preconditionTransform."""
+        if transform == "spectral":
+            return Preconditioner._factorise_spectral(
+                hess, idx, ridge, max_tries, label=label, names=names
+            )
+        if transform == "ridge":
+            return Preconditioner._factorise_ridge(
+                hess, idx, ridge, max_tries, label=label, names=names
+            )
+        raise ValueError(f"unknown preconditioner transform {transform!r}")
+
+    @staticmethod
+    def _factorise_ridge(hess, idx, ridge, max_tries, label="", names=None):
+        """Ridge path: factorise ``H + eps*I``, escalating eps until it succeeds.
+
+        rabbit's original transform, kept as the default. A single scalar ridge
+        cannot serve a block whose curvatures span orders of magnitude -- see
+        :meth:`_factorise_spectral` and the note on --preconditionTransform --
+        so prefer spectral for heterogeneous blocks.
+        """
+        tag = f"{label} " if label else ""
+        if idx.size == 0:
+            logger.warning(f"Preconditioning block {tag}is empty; skipping.")
+            return None
+
+        block = np.asarray(hess, dtype=np.float64)[np.ix_(idx, idx)]
+        # symmetrise: the autodiff Hessian is symmetric only up to roundoff
+        block = 0.5 * (block + block.T)
+
+        diag = np.diag(block)
+        scale = float(np.max(diag)) if diag.size else 0.0
+        if not np.isfinite(scale) or scale <= 0.0:
+            logger.warning(
+                f"Preconditioning block {tag}has no positive diagonal "
+                f"(max diag = {scale}); skipping.  [{_describe(idx, names)}]"
+            )
+            return None
+
+        cond_before = _cond_corr(block)
+        # Ridge schedule: try the caller's value first, since for a positive
+        # definite block that is all that is needed and the Cholesky is cheap.
+        # Only if that fails is the spectrum worth the extra O(m^3): the ridge
+        # required to restore definiteness is set by the most negative
+        # eigenvalue, so it can be computed rather than guessed. Escalating by
+        # powers of a hundred instead used to overshoot badly -- blocks needing
+        # 0.03 were skipped after 1e-4 failed and 1e-2 was tried next.
+        schedule = [ridge]
+        for itry in range(max_tries):
+            if itry >= len(schedule):
+                if itry == 1:
+                    w = np.linalg.eigvalsh(block)
+                    lam_min, lam_max = float(w[0]), float(w[-1])
+                    if lam_min < 0.0:
+                        # enough to make it positive definite, plus a margin so
+                        # the smallest eigenvalue is not left at zero
+                        need = abs(lam_min) + max(
+                            0.1 * abs(lam_min), 1e-8 * abs(lam_max)
+                        )
+                        schedule.append(need / scale)
+                        logger.debug(
+                            f"{tag}block has lam_min={lam_min:.3g} "
+                            f"(max|diag|={scale:.3g}); ridge from the spectrum: "
+                            f"{schedule[-1]:.3g} x max|diag|"
+                        )
+                    else:
+                        schedule.append(max(schedule[-1], 1e-12) * 100.0)
+                else:
+                    schedule.append(max(schedule[-1], 1e-12) * 100.0)
+            eps = schedule[itry]
+            trial = block.copy()
+            if eps > 0.0:
+                trial[np.diag_indices_from(trial)] += eps * scale
+            try:
+                chol = scipy.linalg.cholesky(trial, lower=True)
+            except scipy.linalg.LinAlgError:
+                logger.debug(
+                    f"Preconditioner Cholesky failed for {tag}block "
+                    f"with ridge {eps:.3g} x max|diag| (try {itry + 1})"
+                )
+                continue
+            # Conditioning actually achieved: L^-1 B L^-T for the *un-ridged*
+            # block B. Using the ridged matrix here would return 1 by
+            # construction and measure nothing.
+            tb = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
+            tb = scipy.linalg.solve_triangular(chol, tb.T, lower=True, trans="N").T
+            cond_after = _cond_corr(tb)
+            logger.debug(
+                f"Preconditioning {tag}block of {idx.size} parameters from the "
+                f"reference Hessian (ridge {eps:.3g} x max|diag|): correlation "
+                f"condition number {cond_before:.3g} -> {cond_after:.3g} at the "
+                "reference point"
+            )
+            return Block(idx, chol, cond_before, cond_after, label)
+
+        logger.warning(
+            f"Preconditioning block {tag}is not factorisable; the largest ridge "
+            f"tried was {max(schedule):.3g} x max|diag|. Skipping this block."
+        )
+        return None
+
+    @staticmethod
+    def _factorise_spectral(hess, idx, ridge, max_tries, label="", names=None):
         """One block -> a :class:`Block`, or None if it is unusable."""
         tag = f"{label} " if label else ""
         if idx.size == 0:
@@ -302,8 +414,9 @@ class Preconditioner:
         # and the block comes out at condition number 33 instead of 1
         # (tests/test_preconditioner_spectral.py pins exactly this).
         #
-        # `ridge` is therefore unused on this path; it is kept in the signature
-        # so the CLI and callers are unchanged.
+        # `ridge` and `max_tries` are unused on THIS path (they belong to the
+        # ridge transform); the signature is shared so the dispatcher can call
+        # either without special-casing.
         floor = float(np.finfo(np.float64).eps) * float(idx.size) * wmax
         n_floored = int(np.count_nonzero(aw < floor))
         aw = np.maximum(aw, floor if floor > 0 else np.finfo(float).tiny)

--- a/rabbit/preconditioner.py
+++ b/rabbit/preconditioner.py
@@ -162,10 +162,11 @@ class Preconditioner:
         """Build from a reference Hessian, one factorisation per index block.
 
         ``index_blocks`` is a list of index arrays (a single array is accepted
-        and treated as one block). Each block is symmetrised, then a ridge
-        proportional to its largest diagonal entry is added until the Cholesky
-        succeeds. A block that cannot be factorised is dropped -- the others
-        still apply, and a preconditioner must never break a fit.
+        and treated as one block). Each block is symmetrised and then whitened
+        by the Cholesky of ``|H| = Q |Lambda| Q^T`` -- see :meth:`_factorise`
+        for why the absolute value of the spectrum rather than a ridge. A block
+        that cannot be factorised is dropped: the others still apply, and a
+        preconditioner must never break a fit.
         """
         if isinstance(index_blocks, np.ndarray) or (
             index_blocks and np.isscalar(index_blocks[0])
@@ -236,80 +237,102 @@ class Preconditioner:
         block = 0.5 * (block + block.T)
 
         diag = np.diag(block)
-        scale = float(np.max(diag)) if diag.size else 0.0
-        if not np.isfinite(scale) or scale <= 0.0:
+        if diag.size == 0 or not np.all(np.isfinite(block)):
             logger.warning(
-                f"Preconditioning block {tag}has no positive diagonal "
-                f"(max diag = {scale}); skipping.  [{_describe(idx, names)}]"
+                f"Preconditioning block {tag}is empty or non-finite; skipping."
+                f"  [{_describe(idx, names)}]"
             )
             return None
 
         cond_before = _cond_corr(block)
-        # Ridge schedule: try the caller's value first, since for a positive
-        # definite block that is all that is needed and the Cholesky is cheap.
-        # Only if that fails is the spectrum worth the extra O(m^3): the ridge
-        # required to restore definiteness is set by the most negative
-        # eigenvalue, so it can be computed rather than guessed. Escalating by
-        # powers of a hundred instead used to overshoot badly -- blocks needing
-        # 0.03 were skipped after 1e-4 failed and 1e-2 was tried next.
-        schedule = [ridge]
-        for itry in range(max_tries):
-            if itry >= len(schedule):
-                if itry == 1:
-                    w = np.linalg.eigvalsh(block)
-                    lam_min, lam_max = float(w[0]), float(w[-1])
-                    if lam_min < 0.0:
-                        # enough to make it positive definite, plus a margin so
-                        # the smallest eigenvalue is not left at zero
-                        need = abs(lam_min) + max(
-                            0.1 * abs(lam_min), 1e-8 * abs(lam_max)
-                        )
-                        schedule.append(need / scale)
-                        logger.debug(
-                            f"{tag}block has lam_min={lam_min:.3g} "
-                            f"(max|diag|={scale:.3g}); ridge from the spectrum: "
-                            f"{schedule[-1]:.3g} x max|diag|"
-                        )
-                    else:
-                        schedule.append(max(schedule[-1], 1e-12) * 100.0)
-                else:
-                    schedule.append(max(schedule[-1], 1e-12) * 100.0)
-            eps = schedule[itry]
-            trial = block.copy()
-            if eps > 0.0:
-                trial[np.diag_indices_from(trial)] += eps * scale
-            try:
-                chol = scipy.linalg.cholesky(trial, lower=True)
-            except scipy.linalg.LinAlgError:
-                logger.debug(
-                    f"Preconditioner Cholesky failed for {tag}block "
-                    f"with ridge {eps:.3g} x max|diag| (try {itry + 1})"
-                )
-                continue
-            # Conditioning actually achieved: L^-1 B L^-T for the *un-ridged*
-            # block B. Using the ridged matrix here would return 1 by
-            # construction and measure nothing.
-            tb = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
-            tb = scipy.linalg.solve_triangular(chol, tb.T, lower=True, trans="N").T
-            cond_after = _cond_corr(tb)
-            # Log the MEMBERS, not just the size: "block of 14 parameters" does
-            # not say which 14, so there is no way to tell from a log which
-            # parameters the transform actually helped. Names come from the
-            # optional `names` argument; without it this degrades to indices.
-            who = _describe(idx, names)
-            logger.debug(
-                f"Preconditioning {tag}block of {idx.size} parameters from the "
-                f"reference Hessian (ridge {eps:.3g} x max|diag|): correlation "
-                f"condition number {cond_before:.3g} -> {cond_after:.3g} at the "
-                f"reference point  [{who}]"
-            )
-            return Block(idx, chol, cond_before, cond_after, label)
 
-        logger.warning(
-            f"Preconditioning block {tag}is not factorisable; the largest ridge "
-            f"tried was {max(schedule):.3g} x max|diag|. Skipping this block."
+        # SPECTRAL whitening: factorise |H| = Q |Lambda| Q^T rather than
+        # ridging H into definiteness.
+        #
+        # Why not a ridge. A ridge is ONE number and it has to be at least
+        # |lam_min| to restore definiteness, so in a block whose curvatures span
+        # orders of magnitude it swamps every direction softer than itself.
+        # Those directions come back out of the whitening as near-null: measured
+        # on a real 3-parameter case with curvatures (3.3e9, -8.7e6, 1), the
+        # O(1) direction landed at 7e-08 and the block's true condition number
+        # went 3.3e+09 -> 1.44e+08, where the spectral transform gives 1. That
+        # is not a corner case -- it is what happens whenever a constrained
+        # nuisance shares a block with an unconstrained parameter, and it made
+        # the difference between a 3720-parameter fit stalling and converging.
+        #
+        # Taking |Lambda| keeps the SIGN of each direction in the new
+        # coordinates (the true Hessian maps to diag(+1, -1, +1) above), which
+        # matters because trust-krylov exploits negative curvature to escape
+        # saddles; flattening it to +1 would throw that away, and is why the
+        # Gauss-Newton reference matrix does badly here (see
+        # Fitter._reference_matrix).
+        #
+        # For a positive-definite block this is IDENTICAL in result to the
+        # plain Cholesky -- both give exactly the identity -- so nothing is lost
+        # on the easy blocks; it only costs more (measured 11x at m=200, 44x at
+        # m=2112, i.e. 1.7 s once per build, against a fit of tens of minutes).
+        try:
+            w, Q = np.linalg.eigh(block)
+        except np.linalg.LinAlgError as ex:
+            logger.warning(
+                f"Preconditioning block {tag}eigendecomposition failed ({ex}); "
+                f"skipping.  [{_describe(idx, names)}]"
+            )
+            return None
+
+        aw = np.abs(w)
+        wmax = float(np.max(aw))
+        if not np.isfinite(wmax) or wmax <= 0.0:
+            logger.warning(
+                f"Preconditioning block {tag}has an all-zero spectrum; "
+                f"skipping.  [{_describe(idx, names)}]"
+            )
+            return None
+        # Floor the numerically-null directions. A direction indistinguishable
+        # from zero curvature has no scale to whiten to, and 1/sqrt(~0) would
+        # hand the minimizer an enormous spurious step.
+        #
+        # The threshold is the standard numerical-RANK cutoff, eps * m * wmax
+        # (what pinv and lstsq use), NOT the `ridge` parameter. That distinction
+        # is the whole point: whether a direction is resolvable is a question
+        # about floating point, not about physics. Reusing `ridge` here was
+        # tried and is wrong -- at its 1e-8 default and wmax = 3.3e9 the floor
+        # lands at 33, which is ABOVE a genuine curvature of 1.0 in the very
+        # block this transform exists for, so a physical direction gets flattened
+        # and the block comes out at condition number 33 instead of 1
+        # (tests/test_preconditioner_spectral.py pins exactly this).
+        #
+        # `ridge` is therefore unused on this path; it is kept in the signature
+        # so the CLI and callers are unchanged.
+        floor = float(np.finfo(np.float64).eps) * float(idx.size) * wmax
+        n_floored = int(np.count_nonzero(aw < floor))
+        aw = np.maximum(aw, floor if floor > 0 else np.finfo(float).tiny)
+
+        absH = (Q * aw) @ Q.T
+        absH = 0.5 * (absH + absH.T)
+        try:
+            chol = scipy.linalg.cholesky(absH, lower=True)
+        except scipy.linalg.LinAlgError as ex:
+            logger.warning(
+                f"Preconditioning block {tag}Cholesky of |H| failed ({ex}); "
+                f"skipping.  [{_describe(idx, names)}]"
+            )
+            return None
+
+        # Conditioning actually achieved, on the UN-modified block: using |H|
+        # here would return 1 by construction and measure nothing.
+        tb = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
+        tb = scipy.linalg.solve_triangular(chol, tb.T, lower=True, trans="N").T
+        cond_after = _cond_corr(tb)
+        n_neg = int(np.count_nonzero(w < 0.0))
+        logger.debug(
+            f"Preconditioning {tag}block of {idx.size} parameters by spectral "
+            f"whitening of |H| (lam in [{w[0]:.3g}, {w[-1]:.3g}], {n_neg} "
+            f"negative, {n_floored} floored): correlation condition number "
+            f"{cond_before:.3g} -> {cond_after:.3g} at the reference point"
+            f"  [{_describe(idx, names)}]"
         )
-        return None
+        return Block(idx, chol, cond_before, cond_after, label)
 
     # -- the transform ---------------------------------------------------
 

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -456,7 +456,10 @@ def test_fit_is_invariant_on_an_ill_conditioned_block(method):
 
         # default scope must have found the unconstrained polynomial block
         assert pc.enabled and pc.nblock > 1
-        # and it must actually be badly conditioned before, well conditioned after
+        # and it must actually be badly conditioned before, well conditioned
+        # after. These are TRUE condition numbers at both ends, not the
+        # scale-free degeneracy (pc.blocks[i].corr_before) -- see WHAT THE
+        # NUMBERS MEAN in preconditioner.py.
         assert pc.cond_before > 1e3
         assert pc.cond_after < 1e2
         assert check_results("plain", plain, "preconditioned", pre)

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -404,6 +404,44 @@ def test_fit_is_invariant_for_either_reference_source(source):
         assert check_results("plain", plain, f"precond[{source}]", pre)
 
 
+@pytest.mark.parametrize("transform", ["ridge", "spectral"])
+def test_fit_is_invariant_for_either_transform(transform):
+    """Both transforms are only a change of variables, so neither may move the
+    fit. This is what justifies offering the choice at all: the block algebra
+    below shows T^T H T = I, but only a fit shows the minimum staying put."""
+    with tempfile.TemporaryDirectory() as tmp:
+        filename = make_polynomial_tensor(tmp, order=6)
+        plain, _ = _run(filename, "trust-krylov")
+        pre, pc = _run(
+            filename,
+            "trust-krylov",
+            precondition=True,
+            preconditionTransform=transform,
+        )
+        assert pc.enabled and pc.nblock > 1
+        assert check_results("plain", plain, f"precond[{transform}]", pre)
+
+
+def test_default_transform_is_ridge_in_the_parser_and_the_fitter():
+    """The transform default lives in three places (parser, Fitter getattr,
+    _factorise signature). The third is pinned in test_preconditioner_spectral;
+    these are the two that decide what a real run actually does."""
+    from rabbit import parsing
+
+    # get_default rather than parse_args: common_parser has a required
+    # positional (filename), so parsing an empty argv exits
+    assert parsing.common_parser().get_default("preconditionTransform") == "ridge"
+
+    # the Fitter's getattr fallback, for callers whose options predate the flag
+    with tempfile.TemporaryDirectory() as tmp:
+        filename = make_test_tensor(tmp)
+        indata_obj = inputdata.FitInputData(filename)
+        options = make_options()
+        assert not hasattr(options, "preconditionTransform")
+        f = fitter.Fitter(indata_obj, load_model("Mu", indata_obj), options)
+        assert f.precondition_transform == "ridge"
+
+
 @pytest.mark.parametrize("method", ["trust-krylov", "trust-exact"])
 def test_fit_is_invariant_on_an_ill_conditioned_block(method):
     """The case this feature exists for: many correlated unconstrained params.

--- a/tests/test_preconditioner_spectral.py
+++ b/tests/test_preconditioner_spectral.py
@@ -34,9 +34,9 @@ HARD = np.array(
 )
 
 
-def _factorise(block, ridge=1e-8):
+def _factorise(block, ridge=1e-8, transform="spectral"):
     return precond.Preconditioner._factorise(
-        block, np.arange(block.shape[0]), ridge, 4, ""
+        block, np.arange(block.shape[0]), ridge, 4, "", transform=transform
     )
 
 
@@ -96,3 +96,20 @@ def test_near_null_direction_is_floored_not_amplified():
     assert blk is not None
     # the floor keeps L^-1 bounded; without it 1/sqrt(1e-18) = 1e9
     assert np.max(np.abs(blk.chol)) < 1e3
+
+
+def test_default_transform_is_ridge_so_existing_behaviour_is_unchanged():
+    """The spectral transform is opt-in. Shipping it as the default would change
+    the numerics of every --precondition user on a feature that is not ours."""
+    import inspect
+
+    sig = inspect.signature(precond.Preconditioner._factorise)
+    assert sig.parameters["transform"].default == "ridge"
+
+    # and the ridge path still reproduces the failure mode it is known for,
+    # which is the reason spectral exists -- if this ever passes, the ridge
+    # implementation changed underneath us
+    blk = _factorise(HARD, transform="ridge")
+    assert blk is not None
+    t = _whiten(blk.chol, HARD)
+    assert _cond_true(t) > 1e7

--- a/tests/test_preconditioner_spectral.py
+++ b/tests/test_preconditioner_spectral.py
@@ -167,24 +167,84 @@ def test_near_null_direction_is_floored_not_amplified():
     assert blk.chol[0, 0] == pytest.approx(1.0)
 
 
-def test_ridge_can_start_on_an_all_negative_block():
-    """The DEFAULT path must not drop a block for having no positive diagonal.
+def test_all_negative_block_is_dropped_rather_than_made_worse():
+    """The ridge reaches these blocks now, and the guard then declines them.
 
-    The ridge is expressed in units of max|diag|; scaling it by max(diag)
-    instead skipped every all-negative block outright (21 of 34 on one real
-    fit). The first Cholesky still fails, then the spectrum branch sizes the
-    ridge from |lam_min| and it succeeds. Not as good as spectral -- 320
-    against 1 on this block -- but a usable transform beats none.
+    Expressing the ridge in units of max|diag| rather than max(diag) means an
+    all-negative block is no longer rejected before anything is attempted. But
+    such a block needs a ridge of at least |lam_min| ~ max|diag|, which swamps
+    every direction in it, so the result is WORSE than doing nothing -- 30 ->
+    320 here -- and NEVER MAKE IT WORSE drops it. Net behaviour matches the old
+    skip; the difference is that it is now measured and logged rather than
+    inferred from a mislabelled scale test.
     """
     neg = np.diag([-7.5e3, -6.3e4, -2.1e3]).astype(float)
-    blk = _factorise(neg, transform="ridge")
-    assert blk is not None
-    t = _whiten(blk.chol, neg)
-    assert _cond_true(t) < 1e3
-    assert np.all(np.diag(t) < 0)  # signs survive here too
+    assert _factorise(neg, transform="ridge") is None
 
-    spectral = _whiten(_factorise(neg, transform="spectral").chol, neg)
-    assert _cond_true(spectral) < _cond_true(t)
+    # the factorisation itself succeeds -- it is the guard that declines it,
+    # which is what makes this different from the old "no positive diagonal"
+    # rejection
+    raw = precond.Preconditioner._factorise_ridge(
+        neg, np.arange(3), _cond_true(neg), precond._cond_corr(neg), 1e-8, 4
+    )
+    assert raw is not None
+    assert _cond_true(_whiten(raw.chol, neg)) > _cond_true(neg)
+
+    # and the correlation number cannot see it: a diagonal block has the
+    # identity as its correlation matrix at both ends
+    assert precond._cond_corr(neg) == pytest.approx(1.0)
+    assert precond._cond_corr(_whiten(raw.chol, neg)) == pytest.approx(1.0)
+
+    # spectral is what actually rescues the block
+    spec = _factorise(neg, transform="spectral")
+    assert spec is not None
+    assert _cond_true(_whiten(spec.chol, neg)) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_guard_keeps_a_block_the_transform_genuinely_helps():
+    """The guard must not be a blanket refusal -- but which blocks each
+    transform helps is not the same set, which is the whole argument of this PR.
+
+    A positive-definite ill-conditioned block is the ridge's home ground and it
+    is kept. A random INDEFINITE block is not: the ridge degrades it (34 -> 388
+    here) and is declined, while spectral takes it to 1. That asymmetry is the
+    case for the spectral transform, stated as a test rather than as prose.
+    """
+    rng = np.random.default_rng(3)
+    q, _ = np.linalg.qr(rng.standard_normal((12, 12)))
+    pd = q @ np.diag(np.geomspace(1.0, 1e6, 12)) @ q.T
+    for transform in ("ridge", "spectral"):
+        blk = _factorise(pd, transform=transform)
+        assert blk is not None, f"{transform} dropped a PD block it improves"
+        assert blk.cond_after < blk.cond_before
+
+    a = rng.standard_normal((12, 12))
+    indef = a + a.T
+    assert _factorise(indef, transform="ridge") is None  # declined by the guard
+    spec = _factorise(indef, transform="spectral")
+    assert spec is not None
+    assert spec.cond_after == pytest.approx(1.0, rel=1e-6)
+
+
+def test_guard_does_not_act_on_an_already_singular_block():
+    """Ridging a rank-deficient block into shape is the ridge's original job.
+
+    Its true condition number is ~1/eps at both ends, so a ratio between them
+    is noise rather than a measurement -- and the correlation number shows the
+    ridge genuinely helping. So the guard stands down above SINGULAR_COND.
+    """
+    rng = np.random.default_rng(9)
+    q, _ = np.linalg.qr(rng.standard_normal((5, 5)))
+    h = q @ np.diag(np.geomspace(1.0, 1e6, 5)) @ q.T
+    h[:, -1] = h[:, 0]  # exact linear dependence
+    h[-1, :] = h[0, :]
+    h = 0.5 * (h + h.T)
+
+    assert _cond_true(h) > precond.SINGULAR_COND
+    blk = _factorise(h, transform="ridge")
+    assert blk is not None, "an already-singular block must still be ridged"
+    tb = _whiten(blk.chol, h)
+    assert precond._cond_corr(tb) < precond._cond_corr(h)  # what did improve
 
 
 def test_default_transform_is_ridge_so_existing_behaviour_is_unchanged():

--- a/tests/test_preconditioner_spectral.py
+++ b/tests/test_preconditioner_spectral.py
@@ -16,10 +16,9 @@ def _cond_true(m):
     return float(sv[0] / sv[-1])
 
 
-def _whiten(chol, block):
-    """L^-1 B L^-T, the true block in the new coordinates."""
-    t = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
-    return scipy.linalg.solve_triangular(chol, t.T, lower=True, trans="N").T
+# L^-1 B L^-T, the true block in the new coordinates. The module's own, so
+# these tests measure what the log line reports.
+_whiten = precond._whiten
 
 
 # The case that motivated this: curvatures spanning nine orders of magnitude,
@@ -90,12 +89,53 @@ def test_all_negative_block_is_usable():
 
 
 def test_near_null_direction_is_floored_not_amplified():
-    """A genuinely flat direction has no scale to whiten to."""
+    """A genuinely flat direction has no scale to whiten to.
+
+    The quantity to pin is L^-1, not L. L holds sqrt(|lam|), so a near-null
+    direction makes its entries SMALL -- asserting on them passes whether or
+    not the flooring happens.
+    """
     m = np.diag([1.0, 1e-18]).astype(float)
     blk = _factorise(m, ridge=1e-8)
     assert blk is not None
-    # the floor keeps L^-1 bounded; without it 1/sqrt(1e-18) = 1e9
-    assert np.max(np.abs(blk.chol)) < 1e3
+
+    # what the floor bounds: 1/sqrt(eps*m*wmax) rather than 1/sqrt(1e-18) = 1e9
+    floor = np.finfo(np.float64).eps * 2 * 1.0
+    assert np.max(np.abs(np.linalg.inv(blk.chol))) == pytest.approx(
+        1.0 / np.sqrt(floor), rel=0.1
+    )
+
+    # so the protection is a factor of ~21 here (1e9 -> 4.7e7), not unbounded
+    # -> bounded. Enough that the trust region can reject the step; the comment
+    # in _factorise_spectral says so, and this is the number it refers to.
+    unfloored = scipy.linalg.cholesky(np.diag([1.0, 1e-18]), lower=True)
+    gain = np.max(np.abs(np.linalg.inv(unfloored))) / np.max(
+        np.abs(np.linalg.inv(blk.chol))
+    )
+    assert 10.0 < gain < 100.0
+
+    # and the resolvable direction is untouched
+    assert blk.chol[0, 0] == pytest.approx(1.0)
+
+
+def test_ridge_can_start_on_an_all_negative_block():
+    """The DEFAULT path must not drop a block for having no positive diagonal.
+
+    The ridge is expressed in units of max|diag|; scaling it by max(diag)
+    instead skipped every all-negative block outright (21 of 34 on one real
+    fit). The first Cholesky still fails, then the spectrum branch sizes the
+    ridge from |lam_min| and it succeeds. Not as good as spectral -- 320
+    against 1 on this block -- but a usable transform beats none.
+    """
+    neg = np.diag([-7.5e3, -6.3e4, -2.1e3]).astype(float)
+    blk = _factorise(neg, transform="ridge")
+    assert blk is not None
+    t = _whiten(blk.chol, neg)
+    assert _cond_true(t) < 1e3
+    assert np.all(np.diag(t) < 0)  # signs survive here too
+
+    spectral = _whiten(_factorise(neg, transform="spectral").chol, neg)
+    assert _cond_true(spectral) < _cond_true(t)
 
 
 def test_default_transform_is_ridge_so_existing_behaviour_is_unchanged():
@@ -103,8 +143,17 @@ def test_default_transform_is_ridge_so_existing_behaviour_is_unchanged():
     the numerics of every --precondition user on a feature that is not ours."""
     import inspect
 
+    # all three places the default lives, so flipping one cannot pass silently
     sig = inspect.signature(precond.Preconditioner._factorise)
     assert sig.parameters["transform"].default == "ridge"
+    assert (
+        inspect.signature(precond.Preconditioner.from_hessian)
+        .parameters["transform"]
+        .default
+        == "ridge"
+    )
+    # the --preconditionTransform and Fitter defaults, the other two places it
+    # lives, are pinned in test_preconditioner.py (they need the fitter stack)
 
     # and the ridge path still reproduces the failure mode it is known for,
     # which is the reason spectral exists -- if this ever passes, the ridge

--- a/tests/test_preconditioner_spectral.py
+++ b/tests/test_preconditioner_spectral.py
@@ -1,0 +1,98 @@
+"""The spectral transform, and the ridge failure it exists to fix.
+
+These pin the mechanism with concrete numbers so a future change back to a
+scalar ridge cannot pass silently.
+"""
+
+import numpy as np
+import pytest
+import scipy.linalg
+
+from rabbit import preconditioner as precond
+
+
+def _cond_true(m):
+    sv = np.linalg.svd(np.asarray(m, dtype=np.float64), compute_uv=False)
+    return float(sv[0] / sv[-1])
+
+
+def _whiten(chol, block):
+    """L^-1 B L^-T, the true block in the new coordinates."""
+    t = scipy.linalg.solve_triangular(chol, block, lower=True, trans="N")
+    return scipy.linalg.solve_triangular(chol, t.T, lower=True, trans="N").T
+
+
+# The case that motivated this: curvatures spanning nine orders of magnitude,
+# one of them negative. Physically alphaS + NP lambda (huge, and one negative
+# direction) sharing a block with a unit-normalised nuisance.
+HARD = np.array(
+    [
+        [3.3e9, -1.2e8, 30.0],
+        [-1.2e8, -8.7e6, 5.0],
+        [30.0, 5.0, 1.0],
+    ]
+)
+
+
+def _factorise(block, ridge=1e-8):
+    return precond.Preconditioner._factorise(
+        block, np.arange(block.shape[0]), ridge, 4, ""
+    )
+
+
+def test_spectral_whitens_a_block_a_ridge_cannot():
+    blk = _factorise(HARD)
+    assert blk is not None
+    t = _whiten(blk.chol, HARD)
+    # spectral reaches the identity up to sign
+    assert _cond_true(t) == pytest.approx(1.0, rel=1e-6)
+    assert np.allclose(np.abs(np.diag(t)), 1.0, atol=1e-5)
+
+    # and the sign of the negative direction SURVIVES -- trust-krylov needs it
+    assert np.count_nonzero(np.diag(t) < 0) == 1
+
+    # what a scalar ridge would have done instead, for the record
+    lam = np.linalg.eigvalsh(HARD)
+    ridge = abs(lam[0]) * 1.1
+    lr = scipy.linalg.cholesky(HARD + ridge * np.eye(3), lower=True)
+    tr = _whiten(lr, HARD)
+    assert _cond_true(tr) > 1e7  # measured 1.44e+08
+    # the soft direction collapses to near-null: that is the whole failure
+    assert np.min(np.abs(np.diag(tr))) < 1e-6  # measured 7e-08
+
+
+def test_identical_to_cholesky_when_positive_definite():
+    """Nothing is lost on the easy blocks: both give exactly the identity."""
+    rng = np.random.default_rng(0)
+    a = rng.standard_normal((40, 40))
+    pd = a @ a.T + 40.0 * np.eye(40)
+
+    spectral = _whiten(_factorise(pd).chol, pd)
+    plain = _whiten(scipy.linalg.cholesky(pd, lower=True), pd)
+    assert _cond_true(spectral) == pytest.approx(1.0, rel=1e-8)
+    assert _cond_true(plain) == pytest.approx(1.0, rel=1e-8)
+    assert np.allclose(spectral, plain, atol=1e-8)
+
+
+def test_all_negative_block_is_usable():
+    """A block with NO positive diagonal used to be skipped outright.
+
+    Nothing can be whitened by a ridge scaled to max(diag) when that maximum is
+    negative, so 21 of 34 blocks were dropped in a real fit -- exactly the ones
+    needing help. |Lambda| has no such problem.
+    """
+    neg = np.diag([-7.5e3, -6.3e4, -2.1e3]).astype(float)
+    blk = _factorise(neg)
+    assert blk is not None
+    t = _whiten(blk.chol, neg)
+    assert _cond_true(t) == pytest.approx(1.0, rel=1e-6)
+    assert np.all(np.diag(t) < 0)  # still a maximum in every direction
+
+
+def test_near_null_direction_is_floored_not_amplified():
+    """A genuinely flat direction has no scale to whiten to."""
+    m = np.diag([1.0, 1e-18]).astype(float)
+    blk = _factorise(m, ridge=1e-8)
+    assert blk is not None
+    # the floor keeps L^-1 bounded; without it 1/sqrt(1e-18) = 1e9
+    assert np.max(np.abs(blk.chol)) < 1e3

--- a/tests/test_preconditioner_spectral.py
+++ b/tests/test_preconditioner_spectral.py
@@ -10,10 +10,8 @@ import scipy.linalg
 
 from rabbit import preconditioner as precond
 
-
-def _cond_true(m):
-    sv = np.linalg.svd(np.asarray(m, dtype=np.float64), compute_uv=False)
-    return float(sv[0] / sv[-1])
+# the module's own, so these tests measure exactly what the log reports
+_cond_true = precond._cond_true
 
 
 # L^-1 B L^-T, the true block in the new coordinates. The module's own, so
@@ -42,6 +40,12 @@ def _factorise(block, ridge=1e-8, transform="spectral"):
 def test_spectral_whitens_a_block_a_ridge_cannot():
     blk = _factorise(HARD)
     assert blk is not None
+    # the reported pair is the TRUE condition number at both ends, and the
+    # scale-free degeneracy is carried separately -- on this block the latter
+    # is 1.2, which is exactly why it must not be the "after" number
+    assert blk.cond_before == pytest.approx(_cond_true(HARD), rel=1e-6)
+    assert blk.cond_after == pytest.approx(1.0, rel=1e-6)
+    assert blk.corr_before == pytest.approx(precond._cond_corr(HARD), rel=1e-6)
     t = _whiten(blk.chol, HARD)
     # spectral reaches the identity up to sign
     assert _cond_true(t) == pytest.approx(1.0, rel=1e-6)
@@ -58,6 +62,51 @@ def test_spectral_whitens_a_block_a_ridge_cannot():
     assert _cond_true(tr) > 1e7  # measured 1.44e+08
     # the soft direction collapses to near-null: that is the whole failure
     assert np.min(np.abs(np.diag(tr))) < 1e-6  # measured 7e-08
+
+
+@pytest.mark.parametrize("n", [5, 12, 30, 60])
+def test_spectral_leaves_true_condition_number_exactly_one(n):
+    """The spec of the spectral transform, at any block size.
+
+    B and |B| share eigenvectors, so with |B| = L L^T the congruence
+    L^-1 B L^-T sends Lambda to its own signature: `tb` is symmetric AND
+    orthogonal, hence tb^2 = I and true kappa == 1 identically -- not
+    approximately, and not only on a hand-built 3x3.
+
+    This also pins why the *correlation* number is not reported for the
+    whitened block: L is a Cholesky factor rather than the eigenbasis, so
+    diag(tb) picks up the arbitrary orientation between the two and the
+    1/sqrt|diag| normalisation turns it into an artefact that GROWS with block
+    size, while the truth stays 1.
+    """
+    rng = np.random.default_rng(n)
+    a = rng.standard_normal((n, n))
+    block = a + a.T  # symmetric and indefinite, the case that matters
+
+    # nothing floored, or the congruence identity below does not hold
+    w = np.linalg.eigvalsh(block)
+    floor = np.finfo(np.float64).eps * n * np.max(np.abs(w))
+    assert not np.any(np.abs(w) < floor)
+
+    blk = _factorise(block)
+    tb = _whiten(blk.chol, block)
+
+    assert np.allclose(tb @ tb, np.eye(n), atol=1e-8 * n)
+    assert _cond_true(tb) == pytest.approx(1.0, rel=1e-6)
+    assert blk.cond_after == pytest.approx(1.0, rel=1e-6)
+
+    # and the correlation number would have claimed otherwise, increasingly so
+    if n >= 12:
+        assert precond._cond_corr(tb) > 5.0
+
+
+def test_flooring_is_why_true_kappa_is_measured_not_assumed():
+    """A floored direction is one the congruence no longer preserves."""
+    m = np.diag([1.0, -2.0, 1e-20])
+    blk = _factorise(m)
+    tb = _whiten(blk.chol, m)
+    assert not np.allclose(tb @ tb, np.eye(3), atol=1e-6)
+    assert blk.cond_after > 1e3  # legitimately far from 1
 
 
 def test_identical_to_cholesky_when_positive_definite():


### PR DESCRIPTION
Three changes from using `--precondition` on a 3720-parameter fit. The new
behaviour is **opt-in** — the parsed default is `preconditionTransform='ridge'`,
so nothing changes for existing callers, and the default is pinned in all three
places it lives so a future flip cannot pass silently.

> **Updated twice after @davidwalter2's review.** `--stallRelTol` is split out to
> #157. Two of his comments changed the substance here rather than the prose: the
> reported conditioning is now the **true** condition number (§2), and a block is
> **dropped when whitening would make it worse** (§3) — which retracts a claim I
> had made twice.

### 1. Log which parameters are in each block

Blocks were logged by size only ("block of 14 parameters"), so there was no way
to tell from a log which directions a transform had helped — the first question
anyone asks when preconditioning changes a fit's behaviour.

Now on both paths. It was initially wired only into the spectral logging, which
left the default-transform user looking at the very line this PR opens by
complaining about.

### 2. Report the conditioning actually achieved

The summary printed a hardcoded `-> 1`: the list it aggregates held
`cond_before` only, and `Block.cond_after` was computed and never used.

It now reports the **true** condition number at both ends of the arrow, with the
scale-free degeneracy as a separate clause for the incoming block only:

```
ridge     condition number 3.3e+09 -> 1.44e+08, of which degeneracy 1.23
spectral  condition number 3.3e+09 -> 1, of which degeneracy 1.23
```

The correlation number that was there before is scale-invariant by construction,
so it could not see a scale collapse — and the ridge's failure mode *is* a scale
collapse. It printed `1.225 -> 1` for **both** transforms, i.e. it could not
distinguish them at all on the case that motivates having both. On the spectral
path it is worse than blind: `B` and `|B|` share eigenvectors, so with
`|B| = LLᵀ` the congruence sends `Λ` to its own signature, making `tb` symmetric
*and* orthogonal — `tb² = I`, true κ ≡ 1 at any block size. But `L` is a Cholesky
factor, not the eigenbasis, so `diag(tb)` picks up the arbitrary orientation
between the two and the `1/√|diag|` normalisation turns it into an artefact that
*grows* with block size: 1.7 / 7.7 / 21 / 34 at m = 5 / 12 / 30 / 60, worst
exactly where `--preconditionBlocks none` sends you, against a true value of 1
throughout.

That identity is now the spec test, at four block sizes — a better statement of
what the transform does than "reaches the identity up to sign" on one hand-built
3×3. It holds only where nothing was floored (a floored direction is one the
congruence no longer preserves), so κ is still measured per block rather than
asserted, and a second test pins the floored case.

### 3. `--preconditionTransform {ridge,spectral}`, and a ridge fix

Two separate problems, which the first version of this description conflated:

**A scalar ridge cannot serve a heterogeneous block** — it must be at least
`|λ_min|` to restore definiteness, so it swamps every softer direction and the
whitening leaves them near-null. Measured on curvatures `(3.3e9, -8.7e6, 1)`:
the O(1) direction landed at `7e-08` and the block went `3.3e+09 -> 1.44e+08`,
where spectral whitening of `|H| = Q|Λ|Qᵀ` gives `1`. This is a genuine
limitation of one scalar number and it is what spectral is for.

**All-negative blocks were a ridge bug**, not an argument for spectral. `scale`
is only the unit the ridge is expressed in; nothing in the schedule requires it
to come from a positive curvature, so taking it from `max(diag)` rather than
`max|diag|` rejected those blocks before any factorisation was attempted. That
change is provably inert for every block `main` already handled — `chol`
identical to 6.7e-16 relative over 4000 blocks, and necessarily so, since `scale`
cancels between `need/scale` and `eps*scale` from try 2 onward.

**But ridging such a block makes it worse, so it is now dropped.** I had claimed
"a usable transform beats none" on the strength of `cond_after = 320` where the
block used to be skipped. That was wrong: doing nothing leaves it at **30**, so
the transform was 10.7× worse than the skip it replaced. Over 7094 all-negative
blocks at four off-diagonal strengths, ridging degraded the true condition number
in **100%** of them, median 10.8×, and improved **none**.

So the "a preconditioner must never break a fit" principle — previously applied
only to factorisation *failing* — now also covers it *succeeding and making
things worse*: a block whose true κ degrades by more than `DEGRADE_TOLERANCE` is
left unpreconditioned, which restores exactly the `--precondition off` behaviour
for that block. The guard covers the pre-existing ridge path too, not just the
blocks `max|diag|` newly reaches. It cannot key off the correlation number, which
is blind to the clean case: a diagonal block has the identity as its correlation
matrix at both ends, so `diag(-7.5e3, -6.3e4, -2.1e3)` reports `1 -> 1` where the
truth is `30 -> 320`.

It deliberately stands down above `SINGULAR_COND`. A rank-deficient block reads
`5.28e+16 -> 7.32e+16` — a 1.39× "degradation" between two values past `1/eps`,
where the true condition number has stopped being a measurement — while the
*correlation* number shows the ridge genuinely helping it, `3.1e+16 -> 1.4e+12`.
Ridging a rank-deficient block into shape is what the ridge was for, so that is
left alone. It is the mirror image of the all-negative case, and the reason both
metrics are kept rather than one being declared correct.

**Net effect on all-negative blocks, stated plainly since this description
previously oversold it:** they end up unpreconditioned, as before. What changed
is that it is now reached by measurement with a logged reason rather than by a
scale test that was mislabelled (it always said `max|diag|`), and that the same
protection now covers every other block. Spectral is what actually rescues them —
it reaches 1 on the same block.

Spectral agrees **exactly** with the plain Cholesky on a positive-definite block
(both return the identity, verified to 1e-8 on a 40×40), so nothing is lost on
the easy blocks. It costs an eigendecomposition rather than a Cholesky: measured
11× at m=200 and 44× at m=2112, i.e. ~1.7 s once per preconditioner build.
Taking `|Λ|` preserves each direction's sign, which matters because
`trust-krylov` exploits negative curvature to escape saddles.

The cross-option guidance now lives in the `preconditioner.py` module docstring
(`WHITENING EACH BLOCK`, `CHOOSING THE OPTIONS`, `WHAT THE NUMBERS MEAN`,
`NEVER MAKE IT WORSE`) rather than in `--help`, with a pointer from each option —
it is guidance rather than option semantics, and the help strings had grown to
591 characters on a single source line against a file maximum of 186. The short
version is that the advice **inverts**: under ridge, blocking is a correctness
tool; under spectral a larger block is always better or equal, and
`--preconditionBlockThreshold` works against you.

Also times the reference-matrix evaluation, since that is the whole cost of a
rebuild. Measured across three rebuilds on one fit: 130, 424, 139 s — variable
enough with node load that it should be read per-run rather than assumed.

### Tests

97 passing (86 before). `tests/test_preconditioner_spectral.py` pins the ridge
failure mode, the equivalence with Cholesky when positive definite, the
`true κ ≡ 1` spec at four block sizes, the near-null floor, the guard declining
an all-negative block *while `_factorise_ridge` alone succeeds* (so the two
rejection reasons cannot be confused), a block each transform genuinely helps
being kept, the already-singular carve-out, and the ridge default.

Three additions came out of review:

- `test_fit_is_invariant_for_either_transform` in `test_preconditioner.py`. For a
  reparameterisation the decisive property is that the minimum does not move, and
  nothing here ran a fit.
- the near-null floor test asserted on `blk.chol`, whose entries are `√|λ|` and so
  get *smaller* for a near-null direction — it passed with the flooring removed.
  It now asserts on `L⁻¹` and is mutation-checked. The protection is a factor of
  ~21, not "1e9 → bounded", since the floor is `eps·m·wmax`; the comment used to
  promise more than the code delivers.
- the all-negative test now pins the guard rather than a rescue that was not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
