### PR TITLE
callbacks: make the stall threshold relative, with --stallRelTol

### DIFF
--- a/rabbit/callbacks.py
+++ b/rabbit/callbacks.py
@@ -23,7 +23,7 @@ logger = logging.child_logger(__name__)
 
 
 class FitterCallback:
-    def __init__(self, xv, early_stopping=-1, snapshotter=None):
+    def __init__(self, xv, early_stopping=-1, snapshotter=None, stall_rel_tol=0.0):
         self.iiter = 0
         self.xval = xv
         # Optional rabbit.snapshot.Snapshotter. The callback is the only place
@@ -38,6 +38,29 @@ class FitterCallback:
         self.t0 = time.time()
 
         self.early_stopping = early_stopping
+        # Relative improvement over the --earlyStopping window below which the
+        # fit counts as stalled. 0.0, the default, is exactly the original test:
+        # `gained <= 0` is `ref - loss <= 0` is `ref <= loss`, so the behaviour
+        # of every existing caller is bit-identical.
+        #
+        # Why make it relative at all. The exact test fires only on LITERALLY no
+        # improvement over the window, so a fit that crawls never satisfies it
+        # and --maxRestarts never gets a chance to rebuild the preconditioner at
+        # the point the fit has actually reached. That is a real gap in the
+        # trigger, but it is NOT a bug we have observed: replayed against our
+        # own trajectories they keep gaining 0.2-4% per 30 iterations, no
+        # threshold up to 1e-3 fires, and the exact test was correctly reporting
+        # "not stalled". Do not read this option as a fix for a known stall.
+        #
+        # And note what it cannot distinguish: "flat to 1e-4 over 20 iterations"
+        # is also what APPROACHING A MINIMUM looks like, whereas the exact test
+        # only fires once the trust radius has genuinely collapsed. So a
+        # non-zero value will tend to fire near a good minimum and spend a full
+        # reference-Hessian evaluation (measured 130-424 s) on each restart.
+        # RESTART_MIN_IMPROVEMENT bounds the loop and scipy's gtol usually exits
+        # first, so it is not unsafe -- but it is a behaviour change, which is
+        # why it is off by default.
+        self.stall_rel_tol = float(stall_rel_tol)
         # set just before raising, so fit() can tell a recoverable stall apart
         # from a genuine error and restart instead of giving up
         self.stopped_early = False
@@ -56,15 +79,23 @@ class FitterCallback:
         if np.isnan(loss):
             raise ValueError(f"Loss value is NaN at iteration {self.iiter}")
 
-        if (
-            self.early_stopping > 0
-            and len(self.loss_history) > self.early_stopping
-            and self.loss_history[-self.early_stopping] <= loss
-        ):
-            self.stopped_early = True
-            raise ValueError(
-                f"No reduction in loss after {self.early_stopping} iterations, early stopping."
-            )
+        if self.early_stopping > 0 and len(self.loss_history) > self.early_stopping:
+            ref = self.loss_history[-self.early_stopping]
+            gained = ref - loss
+            # scale by |ref| so the threshold means the same thing at loss 1e7
+            # and at loss 1e4; ref == 0 falls back to the absolute test
+            budget = self.stall_rel_tol * abs(ref)
+            if gained <= budget:
+                self.stopped_early = True
+                how = (
+                    f"only {gained / abs(ref):.3g} relative"
+                    if ref
+                    else f"only {gained:.3g} absolute"
+                )
+                raise ValueError(
+                    f"Loss improved {how} over {self.early_stopping} iterations "
+                    f"(threshold {self.stall_rel_tol:.3g}), early stopping."
+                )
 
         self.loss_history.append(loss)
         self.time_history.append(elapsed)

--- a/rabbit/callbacks.py
+++ b/rabbit/callbacks.py
@@ -60,6 +60,15 @@ class FitterCallback:
         # RESTART_MIN_IMPROVEMENT bounds the loop and scipy's gtol usually exits
         # first, so it is not unsafe -- but it is a behaviour change, which is
         # why it is off by default.
+        # Negative would silently WEAKEN the test -- it would require the loss
+        # to get worse before declaring a stall, i.e. a quieter trigger than
+        # the default rather than a louder one.
+        if float(stall_rel_tol) < 0.0:
+            raise ValueError(
+                f"stall_rel_tol must be >= 0, got {stall_rel_tol}. A negative "
+                "threshold would require the loss to WORSEN before the fit "
+                "counts as stalled."
+            )
         self.stall_rel_tol = float(stall_rel_tol)
         # set just before raising, so fit() can tell a recoverable stall apart
         # from a genuine error and restart instead of giving up
@@ -81,12 +90,33 @@ class FitterCallback:
 
         if self.early_stopping > 0 and len(self.loss_history) > self.early_stopping:
             ref = self.loss_history[-self.early_stopping]
-            gained = ref - loss
-            # scale by |ref| so the threshold means the same thing at loss 1e7
-            # and at loss 1e4; ref == 0 falls back to the absolute test
-            budget = self.stall_rel_tol * abs(ref)
-            if gained <= budget:
+            # Scale by |ref| so the threshold means the same thing at loss 1e7
+            # and at loss 1e4; ref == 0 falls back to the absolute test.
+            #
+            # Written as `loss >= ref - budget`, with `budget` short-circuited
+            # at tol == 0, so the default is the ORIGINAL predicate for every
+            # input including the infinities. `ref - loss <= tol * abs(ref)`
+            # is not: with the loss pinned at an infinity both sides are NaN
+            # (inf - inf, and 0.0 * inf), every NaN comparison is False, and
+            # the stall goes undetected where `ref <= loss` sees inf <= inf and
+            # fires. That case is reachable -- __call__ raises on a NaN loss
+            # but not an infinite one, and a Poisson term with a non-positive
+            # prediction and non-zero data gives exactly +inf -- and it is
+            # precisely the collapsed-trust-radius stall --earlyStopping
+            # exists to catch, so missing it means running to
+            # maxiter = 200 * nparams instead.
+            budget = self.stall_rel_tol * abs(ref) if self.stall_rel_tol else 0.0
+            if loss >= ref - budget:
                 self.stopped_early = True
+                if not self.stall_rel_tol:
+                    # unchanged wording on the default path: every existing
+                    # user sees this string, and "improved only 0 relative" is
+                    # an awkward way to say "did not improve"
+                    raise ValueError(
+                        f"No reduction in loss after {self.early_stopping} "
+                        "iterations, early stopping."
+                    )
+                gained = ref - loss
                 how = (
                     f"only {gained / abs(ref):.3g} relative"
                     if ref

--- a/rabbit/fitter.py
+++ b/rabbit/fitter.py
@@ -75,6 +75,7 @@ class Fitter:
         self.indata = indata
 
         self.earlyStopping = options.earlyStopping
+        self.stallRelTol = getattr(options, "stallRelTol", 0.0)
         self.globalImpactsFromJVP = globalImpactsFromJVP
 
         if self.indata.systematic_type not in Fitter.valid_systematic_types:
@@ -2449,7 +2450,12 @@ class Fitter:
 
         with snapshot_on_signal(snapshotter):
             while True:
-                cb = FitterCallback(xval, self.earlyStopping, snapshotter=snapshotter)
+                cb = FitterCallback(
+                    xval,
+                    self.earlyStopping,
+                    snapshotter=snapshotter,
+                    stall_rel_tol=self.stallRelTol,
+                )
                 try:
                     res = scipy.optimize.minimize(
                         scipy_loss,

--- a/rabbit/parsing.py
+++ b/rabbit/parsing.py
@@ -164,6 +164,22 @@ def add_style_args(parser):
     )
 
 
+def _stall_rel_tol(value):
+    """--stallRelTol: a relative improvement, so negative is meaningless.
+
+    A negative threshold would require the loss to WORSEN before the fit counts
+    as stalled, i.e. it weakens the test rather than tightening it, which is
+    the opposite of what anyone reaching for the option wants.
+    """
+    x = float(value)
+    if x < 0.0:
+        raise argparse.ArgumentTypeError(
+            f"must be >= 0, got {x}: a negative threshold would require the "
+            "loss to worsen before the fit counts as stalled"
+        )
+    return x
+
+
 def common_parser():
     """Return a parser with common arguments for fitting scripts (rabbit_fit, rabbit_limit)."""
     parser = argparse.ArgumentParser()
@@ -195,7 +211,7 @@ def common_parser():
     parser.add_argument(
         "--stallRelTol",
         default=0.0,
-        type=float,
+        type=_stall_rel_tol,
         help="Relative loss improvement over the --earlyStopping window below "
         "which the fit counts as stalled. The default 0.0 is exactly the "
         "original test, which fires only on literally NO improvement -- so a "
@@ -206,7 +222,12 @@ def common_parser():
         "crawl from convergence -- flat over the window is also what approaching "
         "a minimum looks like -- so a non-zero value will also fire near a good "
         "minimum, at one reference-Hessian evaluation per restart. Leave it at 0 "
-        "unless a fit is demonstrably crawling.",
+        "unless a fit is demonstrably crawling. For the upper bound: a descent "
+        "at factor f per iteration is declared stalled exactly when "
+        "tol >= 1 - f^N for a window of N = --earlyStopping, so a healthy fit "
+        "converging at 0.1%% per iteration over a window of 20 is flagged by "
+        "anything above 0.0198. Pick the value from your own f and N rather "
+        "than in the abstract.",
     )
     parser.add_argument(
         "--maxRestarts",

--- a/rabbit/parsing.py
+++ b/rabbit/parsing.py
@@ -193,6 +193,22 @@ def common_parser():
         "no progress rather than exiting. Specify -1 to disable.",
     )
     parser.add_argument(
+        "--stallRelTol",
+        default=0.0,
+        type=float,
+        help="Relative loss improvement over the --earlyStopping window below "
+        "which the fit counts as stalled. The default 0.0 is exactly the "
+        "original test, which fires only on literally NO improvement -- so a "
+        "fit that crawls is never detected and, with --maxRestarts, never gets "
+        "its preconditioner rebuilt at the point it has actually reached. "
+        "Something like 1e-4 treats 'improving by a hundredth of a percent per "
+        "hundred iterations' as the stall it is. WARNING: the test cannot tell a "
+        "crawl from convergence -- flat over the window is also what approaching "
+        "a minimum looks like -- so a non-zero value will also fire near a good "
+        "minimum, at one reference-Hessian evaluation per restart. Leave it at 0 "
+        "unless a fit is demonstrably crawling.",
+    )
+    parser.add_argument(
         "--maxRestarts",
         default=-1,
         type=int,

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -229,13 +229,23 @@ def _feed(losses, early_stopping=3, stall_rel_tol=0.0):
     return False, cb
 
 
-# healthy descent, a hard flat, a crawl, and one that gets worse
+# healthy descent, a hard flat, a crawl, one that gets worse, and the inputs
+# where the algebra stops holding: ref == 0.0 (the relative form would divide
+# by zero) and a loss pinned at an infinity (inf - inf and 0.0 * inf are both
+# NaN, and every NaN comparison is False). +inf is REACHABLE -- __call__ raises
+# on a NaN loss but not an infinite one, and a Poisson term with a
+# non-positive prediction and non-zero data gives exactly +inf -- so an
+# equivalence claim that excluded it would be the wrong claim.
 TRAJECTORIES = [
     [10.0, 9.0, 8.0, 7.0, 6.0, 5.0],
     [10.0, 9.0, 9.0, 9.0, 9.0, 9.0],
     [1e4, 1e4 * (1 - 1e-5), 1e4 * (1 - 2e-5), 1e4 * (1 - 3e-5), 1e4 * (1 - 4e-5)],
     [10.0, 9.0, 9.5, 10.0, 10.5, 11.0],
     [0.0, 0.0, 0.0, 0.0, 0.0],
+    [np.inf] * 5,
+    [-np.inf] * 5,
+    [np.inf, np.inf, 5.0, 5.0, 5.0, 5.0],
+    [np.inf, np.inf, np.inf, np.inf, 1.0, 1.0],
 ]
 
 
@@ -292,3 +302,33 @@ def test_stall_rel_tol_defaults_to_zero_everywhere_it_is_set():
         assert not hasattr(options, "stallRelTol")
         f = fitter.Fitter(indata_obj, load_model("Mu", indata_obj), options)
         assert f.stallRelTol == 0.0
+
+
+def test_default_path_keeps_the_original_early_stopping_message():
+    """Every existing user sees this string; the default path must not reword it."""
+    stalled, cb = _feed([10.0, 9.0, 9.0, 9.0, 9.0, 9.0], stall_rel_tol=0.0)
+    assert stalled
+    with pytest.raises(ValueError, match=r"No reduction in loss after 3 iterations"):
+        _raise(cb_losses=[10.0, 9.0, 9.0, 9.0, 9.0, 9.0], stall_rel_tol=0.0)
+
+    # and the relative phrasing only appears when a threshold is in play
+    with pytest.raises(ValueError, match=r"Loss improved only .* relative"):
+        _raise(cb_losses=[1e4 * (1 - 1e-5 * i) for i in range(8)], stall_rel_tol=1e-3)
+
+
+def _raise(cb_losses, stall_rel_tol):
+    cb = FitterCallback(np.zeros(2), early_stopping=3, stall_rel_tol=stall_rel_tol)
+    for i, loss in enumerate(cb_losses):
+        cb(_result(loss, [i, i]))
+
+
+def test_negative_stall_rel_tol_is_rejected():
+    """A negative threshold would require the loss to WORSEN to count as
+    stalled -- it weakens the test, so it is a footgun rather than an option."""
+    with pytest.raises(ValueError, match=r"must be >= 0"):
+        FitterCallback(np.zeros(2), early_stopping=3, stall_rel_tol=-1e-4)
+
+    from rabbit import parsing
+
+    with pytest.raises(SystemExit):
+        parsing.common_parser().parse_args(["d.hdf5", "--stallRelTol", "-1e-4"])

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -12,6 +12,7 @@ import tempfile
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from rabbit import fitter, inputdata
 from rabbit.callbacks import FitterCallback, merge_callbacks
@@ -206,3 +207,88 @@ def test_preconditioner_is_rebuilt_before_every_restart():
                 f"refresh {i} happened at the same point ({moved}); "
                 "the transform was reused, not rebuilt"
             )
+
+
+# -- the stall THRESHOLD -------------------------------------------------
+#
+# --stallRelTol is the only part of this that touches a default-on path
+# (--earlyStopping defaults to 20), so the equivalence at 0.0 is what most
+# wants pinning: it is what guarantees existing callers see no change.
+
+
+def _feed(losses, early_stopping=3, stall_rel_tol=0.0):
+    """Run a loss trajectory through the callback; did it call it a stall?"""
+    cb = FitterCallback(
+        np.zeros(2), early_stopping=early_stopping, stall_rel_tol=stall_rel_tol
+    )
+    for i, loss in enumerate(losses):
+        try:
+            cb(_result(loss, [i, i]))
+        except ValueError:
+            return True, cb
+    return False, cb
+
+
+# healthy descent, a hard flat, a crawl, and one that gets worse
+TRAJECTORIES = [
+    [10.0, 9.0, 8.0, 7.0, 6.0, 5.0],
+    [10.0, 9.0, 9.0, 9.0, 9.0, 9.0],
+    [1e4, 1e4 * (1 - 1e-5), 1e4 * (1 - 2e-5), 1e4 * (1 - 3e-5), 1e4 * (1 - 4e-5)],
+    [10.0, 9.0, 9.5, 10.0, 10.5, 11.0],
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+]
+
+
+@pytest.mark.parametrize("losses", TRAJECTORIES)
+def test_stall_rel_tol_zero_is_exactly_the_original_test(losses):
+    """The default must be bit-identical to the test it generalises.
+
+    ``gained <= 0`` is ``ref - loss <= 0`` is ``ref <= loss``, so this is
+    algebraically guaranteed; pinned because it is the whole basis for calling
+    the new option opt-in. Includes ref == 0.0, the one input where the
+    relative form would divide by zero and has to fall back.
+    """
+    stalled, _ = _feed(losses, stall_rel_tol=0.0)
+
+    # the predicate as it stood before --stallRelTol existed
+    hist, exact = [], False
+    for loss in losses:
+        if len(hist) > 3 and hist[-3] <= loss:
+            exact = True
+            break
+        hist.append(loss)
+
+    assert stalled == exact
+
+
+def test_stall_rel_tol_detects_a_crawl_the_exact_test_misses():
+    """The gap the option exists for: improving, but not meaningfully."""
+    crawl = [1e4 * (1 - 1e-5 * i) for i in range(8)]
+    assert not _feed(crawl, stall_rel_tol=0.0)[0]  # invisible to the exact test
+    assert _feed(crawl, stall_rel_tol=1e-3)[0]
+
+
+def test_stall_rel_tol_leaves_a_healthy_descent_alone():
+    """It must not fire on a fit that is still making real progress."""
+    healthy = [1e4 * 0.5**i for i in range(8)]
+    for tol in (0.0, 1e-4, 1e-3, 1e-2):
+        assert not _feed(healthy, stall_rel_tol=tol)[0], f"fired at tol={tol}"
+
+
+def test_stall_rel_tol_defaults_to_zero_everywhere_it_is_set():
+    """Three places hold this default; a flip in any of them is a behaviour
+    change on a default-on path, so pin all three."""
+    assert FitterCallback(np.zeros(2)).stall_rel_tol == 0.0
+
+    from rabbit import parsing
+
+    assert parsing.common_parser().get_default("stallRelTol") == 0.0
+
+    # and the Fitter's getattr fallback, for callers whose options predate it
+    with tempfile.TemporaryDirectory() as tmp:
+        filename = make_test_tensor(tmp)
+        indata_obj = inputdata.FitInputData(filename)
+        options = make_options()
+        assert not hasattr(options, "stallRelTol")
+        f = fitter.Fitter(indata_obj, load_model("Mu", indata_obj), options)
+        assert f.stallRelTol == 0.0


### PR DESCRIPTION
Split out of #156 at @davidwalter2's request. It was the only change there
touching a default-on path (`--earlyStopping` defaults to 20), so it should be
judged on its own rather than carried along with a preconditioner feature.

### What

The stall test was `loss_history[-N] <= loss`, which fires only on **literally**
no improvement over the window. A fit that crawls therefore never satisfies it,
and `--maxRestarts` never gets a chance to rebuild the preconditioner at the
point the fit has actually reached. `--stallRelTol` makes the threshold relative,
scaled by `|ref|` so it means the same thing at loss 1e7 and at loss 1e4.

The default `0.0` is **exactly** the old test — `gained <= 0` ⟺ `ref - loss <= 0`
⟺ `ref <= loss` — so existing callers are bit-identical. That equivalence is what
the whole option rests on, and it is now pinned over five trajectories including
`ref == 0.0`, the one input where the relative form would divide by zero and has
to fall back to the absolute test.

### In fairness about the motivation

Our own fits do **not** exhibit the crawl. Replayed against real trajectories
they keep gaining 0.2–4% per 30 iterations, no threshold up to 1e-3 fires on
them, and the exact test was correctly reporting "not stalled". The one
3720-parameter run that did stop short of a minimum did so on **100 bit-identical
iterations** — the exact test working as intended.

So this is a gap in the trigger's generality, not a fix for an observed failure.
An earlier version of the code comment asserted otherwise; it has been rewritten
to argue the generalisation on its own terms rather than citing a measurement
that does not hold.

### The caveat, since the option is easy to reach for

The criterion **cannot distinguish converged from stalled**. "Flat to 1e-4 over
20 iterations" is also what approaching a minimum looks like, whereas the exact
test only fires once the trust radius has genuinely collapsed. A non-zero value
will therefore also fire near a good minimum and spend a reference-Hessian
evaluation on each restart — measured 130/424/139 s across three rebuilds on one
fit. `RESTART_MIN_IMPROVEMENT = 1e-9` bounds the loop and scipy's `gtol` usually
exits first, so it is not unsafe, but it is a real behaviour change. Hence off by
default, and the `--help` now warns instead of suggesting a value unprompted.

### Tests

89 passing. New in `tests/test_restart.py`:

- `stall_rel_tol=0.0` is exactly the old predicate, over five trajectories
  (healthy descent, hard flat, crawl, worsening, and all-zero);
- a crawl is detected at 1e-3 and invisible at 0.0;
- a healthy descent survives every threshold up to 1e-2;
- the default is pinned in all three places it lives (parser, `Fitter` getattr,
  `FitterCallback` signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
