### PR TITLE
Add hodor AI code review workflow (Kimi K3 via aigw endpoint)

### DIFF
--- a/.github/hodor/llm-base-url.patch
+++ b/.github/hodor/llm-base-url.patch
@@ -1,0 +1,50 @@
+diff --git a/src/agent.ts b/src/agent.ts
+index 7c4f013..99b3102 100644
+--- a/src/agent.ts
++++ b/src/agent.ts
+@@ -236,17 +236,44 @@ export async function reviewPr(opts: {
+         `Regional bedrock model, region: ${region}, capabilities from ${baseModel.id}`,
+       );
+     } else if (parsed.provider === "openrouter") {
++      // LLM_BASE_URL redirects the OpenAI-compatible fallback to a
++      // self-hosted endpoint (LiteLLM/vLLM gateway, ...). Compat is pinned to
++      // plain OpenAI chat-completions semantics so no OpenRouter-specific
++      // parameter shapes (`reasoning: { effort }`) are sent upstream.
++      // pi-coding-agent defaults reasoning models to effort "medium"; the
++      // thinkingLevelMap below remaps pi levels onto values the endpoint
++      // accepts (Kimi K3 on vLLM: low/high/max only).
++      const customBaseUrl = process.env.LLM_BASE_URL?.trim();
+       piModel = {
+         id: parsed.modelId,
+         name: parsed.modelId,
+         api: "openai-completions",
+         provider: "openrouter",
+-        baseUrl: "https://openrouter.ai/api/v1",
++        baseUrl: customBaseUrl ?? "https://openrouter.ai/api/v1",
+         reasoning: true,
+         input: ["text", "image"] as ("text" | "image")[],
+         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+         contextWindow: 256000,
+         maxTokens: 65536,
++        ...(customBaseUrl
++          ? {
++              compat: {
++                supportsStore: false,
++                supportsDeveloperRole: false,
++                supportsReasoningEffort: true,
++                thinkingFormat: "openai",
++                maxTokensField: "max_completion_tokens",
++              },
++              thinkingLevelMap: {
++                minimal: "low",
++                low: "low",
++                medium: "high",
++                high: "high",
++                xhigh: "max",
++                max: "max",
++              },
++            }
++          : {}),
+       } as Model<Api>;
+       logger.warn(`Using best-effort unregistered OpenRouter model — ${parsed.modelId}`);
+     } else {

--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -86,6 +86,7 @@ jobs:
           BIN="$RUNNER_TEMP/bin"
           mkdir -p "$BIN"
           echo "$BIN" >> "$GITHUB_PATH"
+          export PATH="$BIN:$PATH"
           fetch() { # url sha256 -> extracts tarball into $RUNNER_TEMP
             tmp="$(mktemp)"
             curl -fsSL "$1" -o "$tmp"

--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -58,6 +58,11 @@ jobs:
     steps:
       - name: Check out this repository (patch source)
         uses: actions/checkout@v4
+        with:
+          # hodor reuses this checkout as its review workspace and diffs
+          # against origin/<base>; depth 1 leaves no origin/main ref and
+          # silently degrades reviews to command mode.
+          fetch-depth: 0
 
       - name: Preflight configuration
         run: |

--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -1,12 +1,18 @@
 name: Hodor AI review
 
 # Automated PR code review with hodor (https://github.com/mr-karan/hodor),
-# driven by a self-hosted OpenAI-compatible endpoint (CERN AI gateway).
+# driven by the CERN AI gateway (aigw.cern.ch) serving Kimi K3.
+#
+# aigw.cern.ch is firewalled to the CERN network, so this job MUST run on
+# the repository's CERN-based self-hosted runners; GitHub-hosted runners
+# cannot reach the endpoint (verified: TCP connect blackholed).
 #
 # hodor has no native custom-endpoint support: its OpenAI-compatible fallback
-# model is hardwired to openrouter.ai. We therefore clone hodor at a pinned
-# tag, apply .github/hodor/llm-base-url.patch (honors LLM_BASE_URL and pins
-# the client to plain OpenAI chat-completions semantics), and build it here.
+# model is hardwired to openrouter.ai (its documented LLM_BASE_URL is a stale
+# pre-rewrite artifact). We therefore clone hodor at a pinned tag, apply
+# .github/hodor/llm-base-url.patch (honors LLM_BASE_URL, pins plain OpenAI
+# chat-completions semantics, and remaps reasoning efforts medium/xhigh that
+# the endpoint's chat template rejects), and build it here.
 #
 # Required configuration (organization or repository level):
 #   secret   HODOR_LLM_API_KEY   API key for the endpoint. An *organization*
@@ -42,7 +48,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&
        !github.event.pull_request.draft)
-    runs-on: ubuntu-latest
+    # CERN-network self-hosted runners only (see header comment).
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 30
     permissions:
       contents: read
@@ -71,36 +78,39 @@ jobs:
             exit 1
           fi
 
-      - name: Install review tool dependencies
+      - name: Ensure review tools (gh, rg, fd)
+        # Self-hosted runner image has no guaranteed gh/rg/fd and no sudo;
+        # fall back to pinned static builds in a job-local bin dir.
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq ripgrep fd-find
-          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
-
-      - name: Diagnose aigw connectivity (temporary)
-        continue-on-error: true
-        run: |
-          T='dns=%{time_namelookup} connect=%{time_connect} tls=%{time_appconnect} firstbyte=%{time_starttransfer} total=%{time_total} http=%{http_code}\n'
-          echo "=== A: baseline, small non-stream, low effort ==="
-          timeout 60 curl -sS https://aigw.cern.ch/v1/chat/completions \
-            -H "Authorization: Bearer $LLM_API_KEY" -H "Content-Type: application/json" \
-            -d '{"model":"Kimi-K3-FLATIRON","messages":[{"role":"user","content":"Say OK"}],"max_completion_tokens":16,"reasoning_effort":"low"}' \
-            -o /tmp/a.json -w "$T" && head -c 200 /tmp/a.json
-          echo "=== B: streamed, high effort, long generation ==="
-          timeout 400 curl -sSN https://aigw.cern.ch/v1/chat/completions \
-            -H "Authorization: Bearer $LLM_API_KEY" -H "Content-Type: application/json" \
-            -d '{"model":"Kimi-K3-FLATIRON","messages":[{"role":"user","content":"Think carefully, then list the first 40 prime numbers with a one-line comment about each."}],"max_completion_tokens":65536,"reasoning_effort":"high","stream":true}' \
-            -o /tmp/b.sse -w "$T" ; echo "chunks=$(grep -c '^data:' /tmp/b.sse)"; head -c 200 /tmp/b.sse
-          echo "=== C: streamed, high effort, hodor-sized prompt (~200KB) ==="
-          CTX="$(for i in $(seq 30); do cat .github/hodor/llm-base-url.patch .github/workflows/hodor-review.yml; done)"
-          SYS="$(printf 'You are a code review agent. Follow the review protocol exactly.\n%.0s' $(seq 200))"
-          jq -n --arg sys "$SYS" --arg ctx "$CTX" \
-            '{model:"Kimi-K3-FLATIRON", messages:[{role:"system",content:$sys},{role:"user",content:("Background context:\n" + $ctx + "\n\nThink step by step, then reply with exactly: DONE")}], max_completion_tokens:65536, reasoning_effort:"high", stream:true}' \
-            > /tmp/c-payload.json
-          timeout 400 curl -sSN https://aigw.cern.ch/v1/chat/completions \
-            -H "Authorization: Bearer $LLM_API_KEY" -H "Content-Type: application/json" \
-            -d @/tmp/c-payload.json \
-            -o /tmp/c.sse -w "$T" ; echo "chunks=$(grep -c '^data:' /tmp/c.sse)"; head -c 200 /tmp/c.sse
+          set -e
+          BIN="$RUNNER_TEMP/bin"
+          mkdir -p "$BIN"
+          echo "$BIN" >> "$GITHUB_PATH"
+          fetch() { # url sha256 -> extracts tarball into $RUNNER_TEMP
+            tmp="$(mktemp)"
+            curl -fsSL "$1" -o "$tmp"
+            echo "$2  $tmp" | sha256sum -c -
+            tar -xzf "$tmp" -C "$RUNNER_TEMP"
+            rm -f "$tmp"
+          }
+          command -v gh >/dev/null || {
+            fetch https://github.com/cli/cli/releases/download/v2.83.0/gh_2.83.0_linux_amd64.tar.gz \
+                  a5cf6cdb40fc67751adf561126b3314044779cea81ba4f254fbe8e9a69f1676f
+            cp "$RUNNER_TEMP/gh_2.83.0_linux_amd64/bin/gh" "$BIN/"
+          }
+          command -v rg >/dev/null || {
+            fetch https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz \
+                  1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599
+            cp "$RUNNER_TEMP/ripgrep-15.1.0-x86_64-unknown-linux-musl/rg" "$BIN/"
+          }
+          command -v fd >/dev/null || {
+            fetch https://github.com/sharkdp/fd/releases/download/v10.5.0/fd-v10.5.0-x86_64-unknown-linux-musl.tar.gz \
+                  761c72dc8e120d85b22292063be8a796e2eeb20eb3e4f38b8fa2343ccf3514a7
+            cp "$RUNNER_TEMP/fd-v10.5.0-x86_64-unknown-linux-musl/fd" "$BIN/"
+          }
+          gh --version
+          rg --version | head -1
+          fd --version
 
       - name: Set up bun
         uses: oven-sh/setup-bun@v2
@@ -114,16 +124,18 @@ jobs:
 
       - name: Build patched hodor
         run: |
-          git clone --depth 1 --branch "$HODOR_VERSION" https://github.com/mr-karan/hodor.git hodor-src
-          git -C hodor-src apply ../.github/hodor/llm-base-url.patch
-          cd hodor-src
+          set -e
+          HODOR_SRC="$RUNNER_TEMP/hodor-src"
+          git clone --depth 1 --branch "$HODOR_VERSION" https://github.com/mr-karan/hodor.git "$HODOR_SRC"
+          git -C "$HODOR_SRC" apply "$GITHUB_WORKSPACE/.github/hodor/llm-base-url.patch"
+          cd "$HODOR_SRC"
           bun install --frozen-lockfile
           bun run build
 
       - name: Run hodor review
         run: |
           PR="${{ github.event.pull_request.number || inputs.pr_number }}"
-          bun run hodor-src/dist/cli.js \
+          bun run "$RUNNER_TEMP/hodor-src/dist/cli.js" \
             "https://github.com/${{ github.repository }}/pull/$PR" \
             --model "openrouter/$HODOR_MODEL" \
             --post \

--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -77,6 +77,31 @@ jobs:
           sudo apt-get install -y -qq ripgrep fd-find
           sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
 
+      - name: Diagnose aigw connectivity (temporary)
+        continue-on-error: true
+        run: |
+          T='dns=%{time_namelookup} connect=%{time_connect} tls=%{time_appconnect} firstbyte=%{time_starttransfer} total=%{time_total} http=%{http_code}\n'
+          echo "=== A: baseline, small non-stream, low effort ==="
+          timeout 60 curl -sS https://aigw.cern.ch/v1/chat/completions \
+            -H "Authorization: Bearer $LLM_API_KEY" -H "Content-Type: application/json" \
+            -d '{"model":"Kimi-K3-FLATIRON","messages":[{"role":"user","content":"Say OK"}],"max_completion_tokens":16,"reasoning_effort":"low"}' \
+            -o /tmp/a.json -w "$T" && head -c 200 /tmp/a.json
+          echo "=== B: streamed, high effort, long generation ==="
+          timeout 400 curl -sSN https://aigw.cern.ch/v1/chat/completions \
+            -H "Authorization: Bearer $LLM_API_KEY" -H "Content-Type: application/json" \
+            -d '{"model":"Kimi-K3-FLATIRON","messages":[{"role":"user","content":"Think carefully, then list the first 40 prime numbers with a one-line comment about each."}],"max_completion_tokens":65536,"reasoning_effort":"high","stream":true}' \
+            -o /tmp/b.sse -w "$T" ; echo "chunks=$(grep -c '^data:' /tmp/b.sse)"; head -c 200 /tmp/b.sse
+          echo "=== C: streamed, high effort, hodor-sized prompt (~200KB) ==="
+          CTX="$(for i in $(seq 30); do cat .github/hodor/llm-base-url.patch .github/workflows/hodor-review.yml; done)"
+          SYS="$(printf 'You are a code review agent. Follow the review protocol exactly.\n%.0s' $(seq 200))"
+          jq -n --arg sys "$SYS" --arg ctx "$CTX" \
+            '{model:"Kimi-K3-FLATIRON", messages:[{role:"system",content:$sys},{role:"user",content:("Background context:\n" + $ctx + "\n\nThink step by step, then reply with exactly: DONE")}], max_completion_tokens:65536, reasoning_effort:"high", stream:true}' \
+            > /tmp/c-payload.json
+          timeout 400 curl -sSN https://aigw.cern.ch/v1/chat/completions \
+            -H "Authorization: Bearer $LLM_API_KEY" -H "Content-Type: application/json" \
+            -d @/tmp/c-payload.json \
+            -o /tmp/c.sse -w "$T" ; echo "chunks=$(grep -c '^data:' /tmp/c.sse)"; head -c 200 /tmp/c.sse
+
       - name: Set up bun
         uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -139,5 +139,6 @@ jobs:
           bun run "$RUNNER_TEMP/hodor-src/dist/cli.js" \
             "https://github.com/${{ github.repository }}/pull/$PR" \
             --model "openrouter/$HODOR_MODEL" \
+            --reasoning-effort max \
             --post \
             --require-delivery

--- a/.github/workflows/hodor-review.yml
+++ b/.github/workflows/hodor-review.yml
@@ -1,0 +1,100 @@
+name: Hodor AI review
+
+# Automated PR code review with hodor (https://github.com/mr-karan/hodor),
+# driven by a self-hosted OpenAI-compatible endpoint (CERN AI gateway).
+#
+# hodor has no native custom-endpoint support: its OpenAI-compatible fallback
+# model is hardwired to openrouter.ai. We therefore clone hodor at a pinned
+# tag, apply .github/hodor/llm-base-url.patch (honors LLM_BASE_URL and pins
+# the client to plain OpenAI chat-completions semantics), and build it here.
+#
+# Required configuration (organization or repository level):
+#   secret   HODOR_LLM_API_KEY   API key for the endpoint. An *organization*
+#                                secret is recommended so the same key can be
+#                                shared by every repo running this workflow
+#                                (set visibility to the selected repos).
+#   variable HODOR_LLM_BASE_URL  Optional override for the endpoint base URL.
+#
+# Token/key hygiene: the job is guarded to never run for fork PRs via the
+# pull_request trigger (GitHub withholds secrets there anyway). For a fork PR,
+# a maintainer can vet the change and start a review manually:
+#   Actions -> Hodor AI review -> Run workflow -> PR number
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: number
+
+concurrency:
+  group: hodor-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Fork PRs on the pull_request trigger get no secrets; skip them.
+    # Skip drafts; reviews start when the PR is marked ready.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       !github.event.pull_request.draft)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write # review comments on the PR
+      issues: write # PR comments are issue comments via the API
+    env:
+      HODOR_VERSION: v0.7.7
+      LLM_BASE_URL: ${{ vars.HODOR_LLM_BASE_URL || 'https://aigw.cern.ch/v1' }}
+      HODOR_MODEL: ${{ vars.HODOR_LLM_MODEL || 'Kimi-K3-FLATIRON' }}
+      LLM_API_KEY: ${{ secrets.HODOR_LLM_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PI_OFFLINE: "1" # never download rg/fd binaries mid-review
+    steps:
+      - name: Check out this repository (patch source)
+        uses: actions/checkout@v4
+
+      - name: Preflight configuration
+        run: |
+          if [ -z "$LLM_API_KEY" ]; then
+            echo "::error::HODOR_LLM_API_KEY secret is not configured. Add it as an organization or repository secret."
+            exit 1
+          fi
+
+      - name: Install review tool dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep fd-find
+          sudo ln -sf "$(command -v fdfind)" /usr/local/bin/fd
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: hodor-${{ env.HODOR_VERSION }}-${{ hashFiles('.github/hodor/llm-base-url.patch') }}
+          restore-keys: hodor-
+
+      - name: Build patched hodor
+        run: |
+          git clone --depth 1 --branch "$HODOR_VERSION" https://github.com/mr-karan/hodor.git hodor-src
+          git -C hodor-src apply ../.github/hodor/llm-base-url.patch
+          cd hodor-src
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Run hodor review
+        run: |
+          PR="${{ github.event.pull_request.number || inputs.pr_number }}"
+          bun run hodor-src/dist/cli.js \
+            "https://github.com/${{ github.repository }}/pull/$PR" \
+            --model "openrouter/$HODOR_MODEL" \
+            --post \
+            --require-delivery


### PR DESCRIPTION
## What

Adds `.github/workflows/hodor-review.yml`: agentic PR review with [hodor](https://github.com/mr-karan/hodor) @ commit `8a97b507` (v0.7.7), driving Kimi K3 (`Kimi-K3-FLATIRON`) on the CERN AI gateway (`https://aigw.cern.ch/v1`, OpenAI-compatible), posting the review as a PR review at `--reasoning-effort max`.

## Where it runs

`aigw.cern.ch` is firewalled to the CERN network — TCP from GitHub-hosted runners is blackholed (verified: ~136 s dropped-SYN connect timeouts). The job therefore runs on the repo's CERN-based **self-hosted runners** (`[self-hosted, linux, x64]`, same as `main.yml`), with self-sufficient tooling (sha256-pinned static `gh`/`rg`/`fd` fallback, no sudo assumptions).

## Trigger model

`pull_request_target`, deliberately: plain `pull_request` never receives secrets for fork PRs — almost all of this repo's PRs are forks — so the endpoint key would be missing exactly where review is needed. The workflow, patch, and `models.json` are always taken from the **base branch**, and who may run is governed by the repository's existing fork-contributor approval gate (`first_time_contributors`: approval required until a contributor's first merged commit, then automatic), the same gate CI inherits. Drafts are skipped; `workflow_dispatch` with a PR number remains for manual runs. The workflow starts auto-firing only once merged (pull_request_target resolves workflows from the base branch).

## Endpoint config: `.github/hodor/models.json`

hodor/pi have no custom-endpoint support out of the box (stock `LLM_BASE_URL` is a stale pre-rewrite artifact). `custom-models.patch` is two hunks: honor `HODOR_MODELS_JSON` (a pi-format models file) and accept its provider prefixes in `--model`. All endpoint specifics — base URL, 1M context, 131072 max tokens, compat quirks (`thinkingFormat: openai`, no `store`/`developer` role), and the thinking-level remap (pi defaults to `medium`, which the endpoint's chat template rejects; only `low`/`high`/`max` accepted) — live in the checked-in models.json, not in the patch.

## Secrets

`HODOR_LLM_API_KEY` as an **organization** secret shared with the repos running this workflow. Exposure model, stated precisely: this job runs *with* secrets where fork `pull_request` runs of `main.yml` never receive any, and the repo's approval gate (`first_time_contributors`) becomes automatic after a contributor's first merged commit — so the auto-running set is org members plus every fork author with ≥1 merged PR. That set is limited to established collaborators at time of writing (incl. all four recent fork contributors) and is accepted deliberately; worst case on exfiltration is aigw quota abuse (the job's `GITHUB_TOKEN` is task-scoped). The org secret's visibility must be limited to repos with at-least-as-strict fork-PR gating. Upgrade path if the trusted set widens: snapshot `.agents/skills` from the base tree and point hodor's skillPaths at the copy (hunk-sized hodor change, would go upstream). Optional repo variable `HODOR_LLM_MODEL` overrides the model id.


## Verification

- Patch applies cleanly to pristine `8a97b507` (`git apply --check`), `tsc --noEmit` clean.
- Live rehearsal on an upstream-branch PR: full run on the self-hosted runner → review posted as a PR review (19 turns, 23 tool calls, 2m30s).
- models.json path smoke-tested end-to-end locally (`--model cern/Kimi-K3-FLATIRON`) against the real endpoint.
- Failure-driven fixes baked in: `fetch-depth: 0` (diff pre-fetch), runner switch, PATH export inside the tool step.